### PR TITLE
(Fix) Updated autogenerated header in contracts source files

### DIFF
--- a/scripts/compileContract.js
+++ b/scripts/compileContract.js
@@ -16,7 +16,7 @@ fs.readFile(inputFilePath, "utf8", function(err, content) {
 		return console.log(err.message);
 	}
 
-	content = "// Created using ICO Wizard https://github.com/oraclesorg/ico-wizard by Oracles Network \n" + content;
+	content = "// Created using ICO Wizard https://github.com/poanetwork/ico-wizard by POA Network \n" + content;
 	if (!isExtended) return compileContract(content);
 
 	addExtendedCode(extensionFilePath, content, function(err, contentUpdated) {


### PR DESCRIPTION
Closes #425 

**Problem**: autogenerated header in contracts source files is outdated (previous organization and network names)
**Solution**: change autogenerated header in contracts source files