### PR TITLE
(Fix) web3.js@1.0.0-beta.27 upstream merged

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = master
 [submodule "submodules/oracles-web3-1.0"]
 	path = submodules/oracles-web3-1.0
-	url = https://github.com/poanetwork/web3.js
+	url = https://github.com/oraclesorg/web3.js
 	branch = 1.0

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = master
 [submodule "submodules/oracles-web3-1.0"]
 	path = submodules/oracles-web3-1.0
-	url = https://github.com/oraclesorg/web3.js
+	url = https://github.com/poanetwork/web3.js
 	branch = 1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -5185,6 +5185,229 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "ganache-cli": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.0.3.tgz",
+      "integrity": "sha512-C7a8su4Zwtootvcy9HtroshTsyUtLC51+aOGUREpy/G4CXbAuLa3nNQri2NyFdqGyOrm/D+jxYP/PWnnrGLyXg==",
+      "dev": true,
+      "requires": {
+        "webpack": "3.10.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "ajv-keywords": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "webpack": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
+          "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.2.1",
+            "acorn-dynamic-import": "2.0.2",
+            "ajv": "5.5.2",
+            "ajv-keywords": "2.1.1",
+            "async": "2.5.0",
+            "enhanced-resolve": "3.4.1",
+            "escope": "3.6.0",
+            "interpret": "1.0.4",
+            "json-loader": "0.5.7",
+            "json5": "0.5.1",
+            "loader-runner": "2.3.0",
+            "loader-utils": "1.1.0",
+            "memory-fs": "0.4.1",
+            "mkdirp": "0.5.1",
+            "node-libs-browser": "2.0.0",
+            "source-map": "0.5.7",
+            "supports-color": "4.5.0",
+            "tapable": "0.2.8",
+            "uglifyjs-webpack-plugin": "0.4.6",
+            "watchpack": "1.4.0",
+            "webpack-sources": "1.0.1",
+            "yargs": "8.0.2"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0"
+          }
+        }
+      }
+    },
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -7302,6 +7525,21 @@
           "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
         },
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
+        },
         "jest-cli": {
           "version": "20.0.4",
           "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
@@ -7337,6 +7575,26 @@
             "which": "1.3.0",
             "worker-farm": "1.5.1",
             "yargs": "7.1.0"
+          }
+        },
+        "yargs": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "5.0.0"
           }
         }
       }
@@ -7507,10 +7765,45 @@
         "yargs": "7.1.0"
       },
       "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
+        },
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+        },
+        "yargs": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "5.0.0"
+          }
         }
       }
     },
@@ -15414,6 +15707,46 @@
         "lodash": "4.17.4",
         "scss-tokenizer": "0.2.3",
         "yargs": "7.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "yargs": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "5.0.0"
+          }
+        }
       }
     },
     "sax": {
@@ -16959,26 +17292,72 @@
     "web3": {
       "version": "file:submodules/oracles-web3-1.0/packages/web3",
       "requires": {
-        "web3-bzz": "1.0.0-beta.22",
-        "web3-core": "1.0.0-beta.22",
-        "web3-eth": "1.0.0-beta.22",
-        "web3-eth-personal": "1.0.0-beta.22",
-        "web3-net": "1.0.0-beta.22",
-        "web3-shh": "1.0.0-beta.22",
-        "web3-utils": "1.0.0-beta.22"
+        "web3-bzz": "1.0.0-beta.27",
+        "web3-core": "1.0.0-beta.27",
+        "web3-eth": "1.0.0-beta.27",
+        "web3-eth-personal": "1.0.0-beta.27",
+        "web3-net": "1.0.0-beta.27",
+        "web3-shh": "1.0.0-beta.27",
+        "web3-utils": "1.0.0-beta.27"
       },
       "dependencies": {
         "web3-bzz": {
-          "version": "1.0.0-beta.22",
+          "version": "1.0.0-beta.27",
           "bundled": true,
           "requires": {
             "got": "7.1.0",
-            "swarm-js": "0.1.35",
+            "swarm-js": "0.1.37",
             "underscore": "1.8.3"
           },
           "dependencies": {
+            "accepts": {
+              "version": "1.3.4",
+              "bundled": true,
+              "requires": {
+                "mime-types": "2.1.17",
+                "negotiator": "0.6.1"
+              }
+            },
+            "ajv": {
+              "version": "5.5.2",
+              "bundled": true,
+              "requires": {
+                "co": "4.6.0",
+                "fast-deep-equal": "1.0.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+              }
+            },
             "any-promise": {
               "version": "1.3.0",
+              "bundled": true
+            },
+            "array-flatten": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "asn1": {
+              "version": "0.2.3",
+              "bundled": true
+            },
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "async-limiter": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "bundled": true
+            },
+            "aws-sign2": {
+              "version": "0.7.0",
+              "bundled": true
+            },
+            "aws4": {
+              "version": "1.6.0",
               "bundled": true
             },
             "balanced-match": {
@@ -16988,6 +17367,14 @@
             "base64-js": {
               "version": "1.2.1",
               "bundled": true
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "tweetnacl": "0.14.5"
+              }
             },
             "bl": {
               "version": "1.2.1",
@@ -17004,8 +17391,35 @@
               }
             },
             "bluebird": {
-              "version": "2.11.0",
+              "version": "3.5.1",
               "bundled": true
+            },
+            "bn.js": {
+              "version": "4.11.8",
+              "bundled": true
+            },
+            "body-parser": {
+              "version": "1.18.2",
+              "bundled": true,
+              "requires": {
+                "bytes": "3.0.0",
+                "content-type": "1.0.4",
+                "debug": "2.6.9",
+                "depd": "1.1.1",
+                "http-errors": "1.6.2",
+                "iconv-lite": "0.4.19",
+                "on-finished": "2.3.0",
+                "qs": "6.5.1",
+                "raw-body": "2.3.2",
+                "type-is": "1.6.15"
+              }
+            },
+            "boom": {
+              "version": "4.3.1",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
             },
             "brace-expansion": {
               "version": "1.1.8",
@@ -17013,6 +17427,17 @@
               "requires": {
                 "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
+              }
+            },
+            "brorand": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "browserify-sha3": {
+              "version": "0.0.1",
+              "bundled": true,
+              "requires": {
+                "js-sha3": "0.3.1"
               }
             },
             "buffer": {
@@ -17034,6 +17459,25 @@
                 "tape": "3.6.1"
               }
             },
+            "bytes": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true
+            },
+            "co": {
+              "version": "4.6.0",
+              "bundled": true
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              }
+            },
             "commander": {
               "version": "2.8.1",
               "bundled": true,
@@ -17045,9 +17489,63 @@
               "version": "0.0.1",
               "bundled": true
             },
+            "content-disposition": {
+              "version": "0.5.2",
+              "bundled": true
+            },
+            "content-type": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "cookie": {
+              "version": "0.3.1",
+              "bundled": true
+            },
+            "cookie-signature": {
+              "version": "1.0.6",
+              "bundled": true
+            },
             "core-util-is": {
               "version": "1.0.2",
               "bundled": true
+            },
+            "cors": {
+              "version": "2.8.4",
+              "bundled": true,
+              "requires": {
+                "object-assign": "4.1.1",
+                "vary": "1.1.2"
+              }
+            },
+            "cryptiles": {
+              "version": "3.1.2",
+              "bundled": true,
+              "requires": {
+                "boom": "5.2.0"
+              },
+              "dependencies": {
+                "boom": {
+                  "version": "5.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "hoek": "4.2.0"
+                  }
+                }
+              }
+            },
+            "dashdash": {
+              "version": "1.14.1",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              }
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
             },
             "decompress": {
               "version": "4.2.0",
@@ -17076,7 +17574,7 @@
               "requires": {
                 "file-type": "5.2.0",
                 "is-stream": "1.1.0",
-                "tar-stream": "1.5.4"
+                "tar-stream": "1.5.5"
               }
             },
             "decompress-tarbz2": {
@@ -17137,6 +17635,18 @@
               "version": "0.0.0",
               "bundled": true
             },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "depd": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "destroy": {
+              "version": "1.0.4",
+              "bundled": true
+            },
             "dom-walk": {
               "version": "0.1.1",
               "bundled": true
@@ -17145,12 +17655,124 @@
               "version": "0.1.4",
               "bundled": true
             },
+            "ecc-jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsbn": "0.1.1"
+              }
+            },
+            "ee-first": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "elliptic": {
+              "version": "6.4.0",
+              "bundled": true,
+              "requires": {
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0",
+                "hash.js": "1.1.3",
+                "hmac-drbg": "1.0.1",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0",
+                "minimalistic-crypto-utils": "1.0.1"
+              }
+            },
+            "encodeurl": {
+              "version": "1.0.1",
+              "bundled": true
+            },
             "end-of-stream": {
               "version": "1.4.0",
               "bundled": true,
               "requires": {
                 "once": "1.4.0"
               }
+            },
+            "escape-html": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "etag": {
+              "version": "1.8.1",
+              "bundled": true
+            },
+            "eth-lib": {
+              "version": "0.1.27",
+              "bundled": true,
+              "requires": {
+                "bn.js": "4.11.8",
+                "elliptic": "6.4.0",
+                "keccakjs": "0.2.1",
+                "nano-json-stream-parser": "0.1.2",
+                "servify": "0.1.12",
+                "ws": "3.3.3",
+                "xhr-request-promise": "0.1.2"
+              }
+            },
+            "express": {
+              "version": "4.16.2",
+              "bundled": true,
+              "requires": {
+                "accepts": "1.3.4",
+                "array-flatten": "1.1.1",
+                "body-parser": "1.18.2",
+                "content-disposition": "0.5.2",
+                "content-type": "1.0.4",
+                "cookie": "0.3.1",
+                "cookie-signature": "1.0.6",
+                "debug": "2.6.9",
+                "depd": "1.1.1",
+                "encodeurl": "1.0.1",
+                "escape-html": "1.0.3",
+                "etag": "1.8.1",
+                "finalhandler": "1.1.0",
+                "fresh": "0.5.2",
+                "merge-descriptors": "1.0.1",
+                "methods": "1.1.2",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.2",
+                "path-to-regexp": "0.1.7",
+                "proxy-addr": "2.0.2",
+                "qs": "6.5.1",
+                "range-parser": "1.2.0",
+                "safe-buffer": "5.1.1",
+                "send": "0.16.1",
+                "serve-static": "1.13.1",
+                "setprototypeof": "1.1.0",
+                "statuses": "1.3.1",
+                "type-is": "1.6.15",
+                "utils-merge": "1.0.1",
+                "vary": "1.1.2"
+              },
+              "dependencies": {
+                "setprototypeof": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "statuses": {
+                  "version": "1.3.1",
+                  "bundled": true
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "extsprintf": {
+              "version": "1.3.0",
+              "bundled": true
+            },
+            "fast-deep-equal": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "fast-json-stable-stringify": {
+              "version": "2.0.0",
+              "bundled": true
             },
             "fd-slicer": {
               "version": "1.0.1",
@@ -17163,12 +17785,52 @@
               "version": "5.2.0",
               "bundled": true
             },
+            "finalhandler": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "debug": "2.6.9",
+                "encodeurl": "1.0.1",
+                "escape-html": "1.0.3",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.2",
+                "statuses": "1.3.1",
+                "unpipe": "1.0.0"
+              },
+              "dependencies": {
+                "statuses": {
+                  "version": "1.3.1",
+                  "bundled": true
+                }
+              }
+            },
             "for-each": {
               "version": "0.3.2",
               "bundled": true,
               "requires": {
                 "is-function": "1.0.1"
               }
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "form-data": {
+              "version": "2.3.1",
+              "bundled": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.17"
+              }
+            },
+            "forwarded": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "fresh": {
+              "version": "0.5.2",
+              "bundled": true
             },
             "fs-extra": {
               "version": "2.1.2",
@@ -17206,16 +17868,19 @@
               "version": "3.0.0",
               "bundled": true
             },
-            "glob": {
-              "version": "7.1.2",
+            "getpass": {
+              "version": "0.1.7",
               "bundled": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
+                "assert-plus": "1.0.0"
+              }
+            },
+            "glob": {
+              "version": "3.2.11",
+              "bundled": true,
+              "requires": {
                 "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "minimatch": "0.3.0"
               }
             },
             "global": {
@@ -17239,7 +17904,7 @@
                 "isurl": "1.0.0",
                 "lowercase-keys": "1.0.0",
                 "p-cancelable": "0.3.0",
-                "p-timeout": "1.2.0",
+                "p-timeout": "1.2.1",
                 "safe-buffer": "5.1.1",
                 "timed-out": "4.0.1",
                 "url-parse-lax": "1.0.0",
@@ -17254,6 +17919,18 @@
               "version": "1.0.1",
               "bundled": true
             },
+            "har-schema": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "har-validator": {
+              "version": "5.0.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
+              }
+            },
             "has-symbol-support-x": {
               "version": "1.4.1",
               "bundled": true
@@ -17264,6 +17941,60 @@
               "requires": {
                 "has-symbol-support-x": "1.4.1"
               }
+            },
+            "hash.js": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
+              }
+            },
+            "hawk": {
+              "version": "6.0.2",
+              "bundled": true,
+              "requires": {
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.0",
+                "sntp": "2.1.0"
+              }
+            },
+            "hmac-drbg": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "hash.js": "1.1.3",
+                "minimalistic-assert": "1.0.0",
+                "minimalistic-crypto-utils": "1.0.1"
+              }
+            },
+            "hoek": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "http-errors": {
+              "version": "1.6.2",
+              "bundled": true,
+              "requires": {
+                "depd": "1.1.1",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.3",
+                "statuses": "1.4.0"
+              }
+            },
+            "http-signature": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
+              }
+            },
+            "iconv-lite": {
+              "version": "0.4.19",
+              "bundled": true
             },
             "ieee754": {
               "version": "1.1.8",
@@ -17279,6 +18010,10 @@
             },
             "inherits": {
               "version": "2.0.3",
+              "bundled": true
+            },
+            "ipaddr.js": {
+              "version": "1.5.2",
               "bundled": true
             },
             "is-function": {
@@ -17305,8 +18040,16 @@
               "version": "1.1.0",
               "bundled": true
             },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
             "isarray": {
               "version": "1.0.0",
+              "bundled": true
+            },
+            "isstream": {
+              "version": "0.1.2",
               "bundled": true
             },
             "isurl": {
@@ -17317,11 +18060,50 @@
                 "is-object": "1.0.1"
               }
             },
+            "js-sha3": {
+              "version": "0.3.1",
+              "bundled": true
+            },
+            "jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "json-schema": {
+              "version": "0.2.3",
+              "bundled": true
+            },
+            "json-schema-traverse": {
+              "version": "0.3.1",
+              "bundled": true
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "bundled": true
+            },
             "jsonfile": {
               "version": "2.4.0",
               "bundled": true,
               "requires": {
                 "graceful-fs": "4.1.11"
+              }
+            },
+            "jsprim": {
+              "version": "1.4.1",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+              }
+            },
+            "keccakjs": {
+              "version": "0.2.1",
+              "bundled": true,
+              "requires": {
+                "browserify-sha3": "0.0.1",
+                "sha3": "1.2.0"
               }
             },
             "lowercase-keys": {
@@ -17345,6 +18127,22 @@
                 }
               }
             },
+            "media-typer": {
+              "version": "0.3.0",
+              "bundled": true
+            },
+            "merge-descriptors": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "methods": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "mime": {
+              "version": "1.4.1",
+              "bundled": true
+            },
             "mime-db": {
               "version": "1.30.0",
               "bundled": true
@@ -17367,11 +18165,20 @@
                 "dom-walk": "0.1.1"
               }
             },
+            "minimalistic-assert": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "minimalistic-crypto-utils": {
+              "version": "1.0.1",
+              "bundled": true
+            },
             "minimatch": {
-              "version": "3.0.4",
+              "version": "0.3.0",
               "bundled": true,
               "requires": {
-                "brace-expansion": "1.1.8"
+                "lru-cache": "2.7.3",
+                "sigmund": "1.0.1"
               }
             },
             "minimist": {
@@ -17400,6 +18207,10 @@
               "version": "0.11.1",
               "bundled": true
             },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            },
             "mz": {
               "version": "2.7.0",
               "bundled": true,
@@ -17409,6 +18220,22 @@
                 "thenify-all": "1.6.0"
               }
             },
+            "nan": {
+              "version": "2.8.0",
+              "bundled": true
+            },
+            "nano-json-stream-parser": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "negotiator": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "bundled": true
+            },
             "object-assign": {
               "version": "4.1.1",
               "bundled": true
@@ -17416,6 +18243,13 @@
             "object-inspect": {
               "version": "0.4.0",
               "bundled": true
+            },
+            "on-finished": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "ee-first": "1.1.1"
+              }
             },
             "once": {
               "version": "1.4.0",
@@ -17433,7 +18267,7 @@
               "bundled": true
             },
             "p-timeout": {
-              "version": "1.2.0",
+              "version": "1.2.1",
               "bundled": true,
               "requires": {
                 "p-finally": "1.0.0"
@@ -17447,12 +18281,24 @@
                 "trim": "0.0.1"
               }
             },
+            "parseurl": {
+              "version": "1.3.2",
+              "bundled": true
+            },
             "path-is-absolute": {
               "version": "1.0.1",
               "bundled": true
             },
+            "path-to-regexp": {
+              "version": "0.1.7",
+              "bundled": true
+            },
             "pend": {
               "version": "1.2.0",
+              "bundled": true
+            },
+            "performance-now": {
+              "version": "2.1.0",
               "bundled": true
             },
             "pify": {
@@ -17482,11 +18328,41 @@
               "version": "1.0.7",
               "bundled": true
             },
+            "proxy-addr": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "forwarded": "0.1.2",
+                "ipaddr.js": "1.5.2"
+              }
+            },
+            "punycode": {
+              "version": "1.4.1",
+              "bundled": true
+            },
+            "qs": {
+              "version": "6.5.1",
+              "bundled": true
+            },
             "query-string": {
               "version": "2.4.2",
               "bundled": true,
               "requires": {
                 "strict-uri-encode": "1.1.0"
+              }
+            },
+            "range-parser": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "raw-body": {
+              "version": "2.3.2",
+              "bundled": true,
+              "requires": {
+                "bytes": "3.0.0",
+                "http-errors": "1.6.2",
+                "iconv-lite": "0.4.19",
+                "unpipe": "1.0.0"
               }
             },
             "readable-stream": {
@@ -17502,6 +18378,34 @@
                 "util-deprecate": "1.0.2"
               }
             },
+            "request": {
+              "version": "2.83.0",
+              "bundled": true,
+              "requires": {
+                "aws-sign2": "0.7.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.1",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.17",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.1",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.1.0"
+              }
+            },
             "resumer": {
               "version": "0.0.0",
               "bundled": true,
@@ -17514,6 +18418,27 @@
               "bundled": true,
               "requires": {
                 "glob": "7.1.2"
+              },
+              "dependencies": {
+                "glob": {
+                  "version": "7.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "fs.realpath": "1.0.0",
+                    "inflight": "1.0.6",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.4",
+                    "once": "1.4.0",
+                    "path-is-absolute": "1.0.1"
+                  }
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "1.1.8"
+                  }
+                }
               }
             },
             "safe-buffer": {
@@ -17527,9 +18452,66 @@
                 "commander": "2.8.1"
               }
             },
+            "send": {
+              "version": "0.16.1",
+              "bundled": true,
+              "requires": {
+                "debug": "2.6.9",
+                "depd": "1.1.1",
+                "destroy": "1.0.4",
+                "encodeurl": "1.0.1",
+                "escape-html": "1.0.3",
+                "etag": "1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "1.6.2",
+                "mime": "1.4.1",
+                "ms": "2.0.0",
+                "on-finished": "2.3.0",
+                "range-parser": "1.2.0",
+                "statuses": "1.3.1"
+              },
+              "dependencies": {
+                "statuses": {
+                  "version": "1.3.1",
+                  "bundled": true
+                }
+              }
+            },
+            "serve-static": {
+              "version": "1.13.1",
+              "bundled": true,
+              "requires": {
+                "encodeurl": "1.0.1",
+                "escape-html": "1.0.3",
+                "parseurl": "1.3.2",
+                "send": "0.16.1"
+              }
+            },
+            "servify": {
+              "version": "0.1.12",
+              "bundled": true,
+              "requires": {
+                "body-parser": "1.18.2",
+                "cors": "2.8.4",
+                "express": "4.16.2",
+                "request": "2.83.0",
+                "xhr": "2.4.1"
+              }
+            },
             "setimmediate": {
               "version": "1.0.5",
               "bundled": true
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "sha3": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "nan": "2.8.0"
+              }
             },
             "sigmund": {
               "version": "1.0.1",
@@ -17544,6 +18526,31 @@
                 "xtend": "4.0.1"
               }
             },
+            "sntp": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            },
+            "sshpk": {
+              "version": "1.13.1",
+              "bundled": true,
+              "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "statuses": {
+              "version": "1.4.0",
+              "bundled": true
+            },
             "strict-uri-encode": {
               "version": "1.1.0",
               "bundled": true
@@ -17555,6 +18562,10 @@
                 "safe-buffer": "5.1.1"
               }
             },
+            "stringstream": {
+              "version": "0.0.5",
+              "bundled": true
+            },
             "strip-dirs": {
               "version": "2.1.0",
               "bundled": true,
@@ -17563,11 +18574,13 @@
               }
             },
             "swarm-js": {
-              "version": "0.1.35",
+              "version": "0.1.37",
               "bundled": true,
               "requires": {
+                "bluebird": "3.5.1",
                 "buffer": "5.0.8",
                 "decompress": "4.2.0",
+                "eth-lib": "0.1.27",
                 "fs-extra": "2.1.2",
                 "fs-promise": "2.0.3",
                 "got": "7.1.0",
@@ -17590,24 +18603,6 @@
                 "object-inspect": "0.4.0",
                 "resumer": "0.0.0",
                 "through": "2.3.8"
-              },
-              "dependencies": {
-                "glob": {
-                  "version": "3.2.11",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "2.0.3",
-                    "minimatch": "0.3.0"
-                  }
-                },
-                "minimatch": {
-                  "version": "0.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "lru-cache": "2.7.3",
-                    "sigmund": "1.0.1"
-                  }
-                }
               }
             },
             "tar": {
@@ -17620,7 +18615,7 @@
               }
             },
             "tar-stream": {
-              "version": "1.5.4",
+              "version": "1.5.5",
               "bundled": true,
               "requires": {
                 "bl": "1.2.1",
@@ -17638,6 +18633,12 @@
                 "fstream": "1.0.11",
                 "mout": "0.11.1",
                 "tar": "2.2.1"
+              },
+              "dependencies": {
+                "bluebird": {
+                  "version": "2.11.0",
+                  "bundled": true
+                }
               }
             },
             "thenify": {
@@ -17662,8 +18663,39 @@
               "version": "4.0.1",
               "bundled": true
             },
+            "tough-cookie": {
+              "version": "2.3.3",
+              "bundled": true,
+              "requires": {
+                "punycode": "1.4.1"
+              }
+            },
             "trim": {
               "version": "0.0.1",
+              "bundled": true
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            },
+            "tweetnacl": {
+              "version": "0.14.5",
+              "bundled": true,
+              "optional": true
+            },
+            "type-is": {
+              "version": "1.6.15",
+              "bundled": true,
+              "requires": {
+                "media-typer": "0.3.0",
+                "mime-types": "2.1.17"
+              }
+            },
+            "ultron": {
+              "version": "1.1.1",
               "bundled": true
             },
             "unbzip2-stream": {
@@ -17693,6 +18725,10 @@
               "version": "1.8.3",
               "bundled": true
             },
+            "unpipe": {
+              "version": "1.0.0",
+              "bundled": true
+            },
             "unzip-response": {
               "version": "1.0.2",
               "bundled": true
@@ -17716,12 +18752,42 @@
               "version": "1.0.2",
               "bundled": true
             },
+            "utils-merge": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "uuid": {
+              "version": "3.1.0",
+              "bundled": true
+            },
+            "vary": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "verror": {
+              "version": "1.10.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "1.3.0"
+              }
+            },
             "wrappy": {
               "version": "1.0.2",
               "bundled": true
             },
+            "ws": {
+              "version": "3.3.3",
+              "bundled": true,
+              "requires": {
+                "async-limiter": "1.0.0",
+                "safe-buffer": "5.1.1",
+                "ultron": "1.1.1"
+              }
+            },
             "xhr": {
-              "version": "2.4.0",
+              "version": "2.4.1",
               "bundled": true,
               "requires": {
                 "global": "4.3.2",
@@ -17740,7 +18806,7 @@
                 "simple-get": "1.4.3",
                 "timed-out": "2.0.0",
                 "url-set-query": "1.0.0",
-                "xhr": "2.4.0"
+                "xhr": "2.4.1"
               },
               "dependencies": {
                 "object-assign": {
@@ -17775,22 +18841,22 @@
           }
         },
         "web3-core": {
-          "version": "1.0.0-beta.22",
+          "version": "1.0.0-beta.27",
           "bundled": true,
           "requires": {
-            "web3-core-helpers": "1.0.0-beta.22",
-            "web3-core-method": "1.0.0-beta.22",
-            "web3-core-requestmanager": "1.0.0-beta.22",
-            "web3-utils": "1.0.0-beta.22"
+            "web3-core-helpers": "1.0.0-beta.27",
+            "web3-core-method": "1.0.0-beta.27",
+            "web3-core-requestmanager": "1.0.0-beta.27",
+            "web3-utils": "1.0.0-beta.27"
           },
           "dependencies": {
             "web3-core-helpers": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
                 "underscore": "1.8.3",
-                "web3-eth-iban": "1.0.0-beta.22",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-eth-iban": "1.0.0-beta.27",
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {
                 "underscore": {
@@ -17798,11 +18864,11 @@
                   "bundled": true
                 },
                 "web3-eth-iban": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bn.js": "4.11.8",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {
                     "bn.js": {
@@ -17810,7 +18876,7 @@
                       "bundled": true
                     },
                     "web3-utils": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.6",
@@ -17831,7 +18897,7 @@
                           }
                         },
                         "ajv": {
-                          "version": "5.3.0",
+                          "version": "5.5.2",
                           "bundled": true,
                           "requires": {
                             "co": "4.6.0",
@@ -18068,7 +19134,7 @@
                             "keccakjs": "0.2.1",
                             "nano-json-stream-parser": "0.1.2",
                             "servify": "0.1.12",
-                            "ws": "3.3.0",
+                            "ws": "3.3.3",
                             "xhr-request-promise": "0.1.2"
                           }
                         },
@@ -18220,7 +19286,7 @@
                           "version": "5.0.3",
                           "bundled": true,
                           "requires": {
-                            "ajv": "5.3.0",
+                            "ajv": "5.5.2",
                             "har-schema": "2.0.0"
                           }
                         },
@@ -18400,7 +19466,7 @@
                           "bundled": true
                         },
                         "nan": {
-                          "version": "2.7.0",
+                          "version": "2.8.0",
                           "bundled": true
                         },
                         "nano-json-stream-parser": {
@@ -18592,7 +19658,7 @@
                             "cors": "2.8.4",
                             "express": "4.16.2",
                             "request": "2.83.0",
-                            "xhr": "2.4.0"
+                            "xhr": "2.4.1"
                           }
                         },
                         "setprototypeof": {
@@ -18603,7 +19669,7 @@
                           "version": "1.2.0",
                           "bundled": true,
                           "requires": {
-                            "nan": "2.7.0"
+                            "nan": "2.8.0"
                           }
                         },
                         "sigmund": {
@@ -18712,7 +19778,7 @@
                           }
                         },
                         "ultron": {
-                          "version": "1.1.0",
+                          "version": "1.1.1",
                           "bundled": true
                         },
                         "underscore": {
@@ -18761,16 +19827,16 @@
                           "bundled": true
                         },
                         "ws": {
-                          "version": "3.3.0",
+                          "version": "3.3.3",
                           "bundled": true,
                           "requires": {
                             "async-limiter": "1.0.0",
                             "safe-buffer": "5.1.1",
-                            "ultron": "1.1.0"
+                            "ultron": "1.1.1"
                           }
                         },
                         "xhr": {
-                          "version": "2.4.0",
+                          "version": "2.4.1",
                           "bundled": true,
                           "requires": {
                             "global": "4.3.2",
@@ -18789,7 +19855,7 @@
                             "simple-get": "1.4.3",
                             "timed-out": "2.0.0",
                             "url-set-query": "1.0.0",
-                            "xhr": "2.4.0"
+                            "xhr": "2.4.1"
                           },
                           "dependencies": {
                             "object-assign": {
@@ -18814,7 +19880,7 @@
                   }
                 },
                 "web3-utils": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bn.js": "4.11.6",
@@ -18835,7 +19901,7 @@
                       }
                     },
                     "ajv": {
-                      "version": "5.3.0",
+                      "version": "5.5.2",
                       "bundled": true,
                       "requires": {
                         "co": "4.6.0",
@@ -19064,7 +20130,7 @@
                         "keccakjs": "0.2.1",
                         "nano-json-stream-parser": "0.1.2",
                         "servify": "0.1.12",
-                        "ws": "3.3.0",
+                        "ws": "3.3.3",
                         "xhr-request-promise": "0.1.2"
                       }
                     },
@@ -19202,7 +20268,7 @@
                       "version": "5.0.3",
                       "bundled": true,
                       "requires": {
-                        "ajv": "5.3.0",
+                        "ajv": "5.5.2",
                         "har-schema": "2.0.0"
                       }
                     },
@@ -19382,7 +20448,7 @@
                       "bundled": true
                     },
                     "nan": {
-                      "version": "2.7.0",
+                      "version": "2.8.0",
                       "bundled": true
                     },
                     "nano-json-stream-parser": {
@@ -19569,7 +20635,7 @@
                         "cors": "2.8.4",
                         "express": "4.16.2",
                         "request": "2.83.0",
-                        "xhr": "2.4.0"
+                        "xhr": "2.4.1"
                       }
                     },
                     "setprototypeof": {
@@ -19580,7 +20646,7 @@
                       "version": "1.2.0",
                       "bundled": true,
                       "requires": {
-                        "nan": "2.7.0"
+                        "nan": "2.8.0"
                       }
                     },
                     "sigmund": {
@@ -19689,7 +20755,7 @@
                       }
                     },
                     "ultron": {
-                      "version": "1.1.0",
+                      "version": "1.1.1",
                       "bundled": true
                     },
                     "underscore": {
@@ -19738,16 +20804,16 @@
                       "bundled": true
                     },
                     "ws": {
-                      "version": "3.3.0",
+                      "version": "3.3.3",
                       "bundled": true,
                       "requires": {
                         "async-limiter": "1.0.0",
                         "safe-buffer": "5.1.1",
-                        "ultron": "1.1.0"
+                        "ultron": "1.1.1"
                       }
                     },
                     "xhr": {
-                      "version": "2.4.0",
+                      "version": "2.4.1",
                       "bundled": true,
                       "requires": {
                         "global": "4.3.2",
@@ -19766,7 +20832,7 @@
                         "simple-get": "1.4.3",
                         "timed-out": "2.0.0",
                         "url-set-query": "1.0.0",
-                        "xhr": "2.4.0"
+                        "xhr": "2.4.1"
                       },
                       "dependencies": {}
                     },
@@ -19786,14 +20852,14 @@
               }
             },
             "web3-core-method": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
                 "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.22",
-                "web3-core-promievent": "1.0.0-beta.22",
-                "web3-core-subscriptions": "1.0.0-beta.22",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-core-helpers": "1.0.0-beta.27",
+                "web3-core-promievent": "1.0.0-beta.27",
+                "web3-core-subscriptions": "1.0.0-beta.27",
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {
                 "underscore": {
@@ -19801,12 +20867,12 @@
                   "bundled": true
                 },
                 "web3-core-helpers": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-eth-iban": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-eth-iban": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {
                     "underscore": {
@@ -19814,16 +20880,16 @@
                       "bundled": true
                     },
                     "web3-eth-iban": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.8",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-utils": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.6",
@@ -19839,7 +20905,7 @@
                   }
                 },
                 "web3-core-promievent": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bluebird": "3.3.1",
@@ -19857,12 +20923,12 @@
                   }
                 },
                 "web3-core-subscriptions": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "eventemitter3": "1.1.1",
                     "underscore": "1.8.3",
-                    "web3-core-helpers": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27"
                   },
                   "dependencies": {
                     "eventemitter3": {
@@ -19874,12 +20940,12 @@
                       "bundled": true
                     },
                     "web3-core-helpers": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "underscore": "1.8.3",
-                        "web3-eth-iban": "1.0.0-beta.22",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-eth-iban": "1.0.0-beta.27",
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {
                         "underscore": {
@@ -19887,16 +20953,16 @@
                           "bundled": true
                         },
                         "web3-eth-iban": {
-                          "version": "1.0.0-beta.22",
+                          "version": "1.0.0-beta.27",
                           "bundled": true,
                           "requires": {
                             "bn.js": "4.11.8",
-                            "web3-utils": "1.0.0-beta.22"
+                            "web3-utils": "1.0.0-beta.27"
                           },
                           "dependencies": {}
                         },
                         "web3-utils": {
-                          "version": "1.0.0-beta.22",
+                          "version": "1.0.0-beta.27",
                           "bundled": true,
                           "requires": {
                             "bn.js": "4.11.6",
@@ -19914,7 +20980,7 @@
                   }
                 },
                 "web3-utils": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bn.js": "4.11.6",
@@ -19935,7 +21001,7 @@
                       }
                     },
                     "ajv": {
-                      "version": "5.3.0",
+                      "version": "5.5.2",
                       "bundled": true,
                       "requires": {
                         "co": "4.6.0",
@@ -20164,7 +21230,7 @@
                         "keccakjs": "0.2.1",
                         "nano-json-stream-parser": "0.1.2",
                         "servify": "0.1.12",
-                        "ws": "3.3.0",
+                        "ws": "3.3.3",
                         "xhr-request-promise": "0.1.2"
                       }
                     },
@@ -20302,7 +21368,7 @@
                       "version": "5.0.3",
                       "bundled": true,
                       "requires": {
-                        "ajv": "5.3.0",
+                        "ajv": "5.5.2",
                         "har-schema": "2.0.0"
                       }
                     },
@@ -20482,7 +21548,7 @@
                       "bundled": true
                     },
                     "nan": {
-                      "version": "2.7.0",
+                      "version": "2.8.0",
                       "bundled": true
                     },
                     "nano-json-stream-parser": {
@@ -20669,7 +21735,7 @@
                         "cors": "2.8.4",
                         "express": "4.16.2",
                         "request": "2.83.0",
-                        "xhr": "2.4.0"
+                        "xhr": "2.4.1"
                       }
                     },
                     "setprototypeof": {
@@ -20680,7 +21746,7 @@
                       "version": "1.2.0",
                       "bundled": true,
                       "requires": {
-                        "nan": "2.7.0"
+                        "nan": "2.8.0"
                       }
                     },
                     "sigmund": {
@@ -20789,7 +21855,7 @@
                       }
                     },
                     "ultron": {
-                      "version": "1.1.0",
+                      "version": "1.1.1",
                       "bundled": true
                     },
                     "underscore": {
@@ -20838,16 +21904,16 @@
                       "bundled": true
                     },
                     "ws": {
-                      "version": "3.3.0",
+                      "version": "3.3.3",
                       "bundled": true,
                       "requires": {
                         "async-limiter": "1.0.0",
                         "safe-buffer": "5.1.1",
-                        "ultron": "1.1.0"
+                        "ultron": "1.1.1"
                       }
                     },
                     "xhr": {
-                      "version": "2.4.0",
+                      "version": "2.4.1",
                       "bundled": true,
                       "requires": {
                         "global": "4.3.2",
@@ -20866,7 +21932,7 @@
                         "simple-get": "1.4.3",
                         "timed-out": "2.0.0",
                         "url-set-query": "1.0.0",
-                        "xhr": "2.4.0"
+                        "xhr": "2.4.1"
                       },
                       "dependencies": {}
                     },
@@ -20886,14 +21952,14 @@
               }
             },
             "web3-core-requestmanager": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
                 "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.22",
-                "web3-providers-http": "1.0.0-beta.22",
-                "web3-providers-ipc": "1.0.0-beta.22",
-                "web3-providers-ws": "1.0.0-beta.22"
+                "web3-core-helpers": "1.0.0-beta.27",
+                "web3-providers-http": "1.0.0-beta.27",
+                "web3-providers-ipc": "1.0.0-beta.27",
+                "web3-providers-ws": "1.0.0-beta.27"
               },
               "dependencies": {
                 "underscore": {
@@ -20901,12 +21967,12 @@
                   "bundled": true
                 },
                 "web3-core-helpers": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-eth-iban": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-eth-iban": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {
                     "underscore": {
@@ -20914,16 +21980,16 @@
                       "bundled": true
                     },
                     "web3-eth-iban": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.8",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-utils": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.6",
@@ -20939,20 +22005,20 @@
                   }
                 },
                 "web3-providers-http": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
-                    "web3-core-helpers": "1.0.0-beta.22",
+                    "web3-core-helpers": "1.0.0-beta.27",
                     "xhr2": "0.1.4"
                   },
                   "dependencies": {
                     "web3-core-helpers": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "underscore": "1.8.3",
-                        "web3-eth-iban": "1.0.0-beta.22",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-eth-iban": "1.0.0-beta.27",
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {
                         "underscore": {
@@ -20960,16 +22026,16 @@
                           "bundled": true
                         },
                         "web3-eth-iban": {
-                          "version": "1.0.0-beta.22",
+                          "version": "1.0.0-beta.27",
                           "bundled": true,
                           "requires": {
                             "bn.js": "4.11.8",
-                            "web3-utils": "1.0.0-beta.22"
+                            "web3-utils": "1.0.0-beta.27"
                           },
                           "dependencies": {}
                         },
                         "web3-utils": {
-                          "version": "1.0.0-beta.22",
+                          "version": "1.0.0-beta.27",
                           "bundled": true,
                           "requires": {
                             "bn.js": "4.11.6",
@@ -20991,12 +22057,12 @@
                   }
                 },
                 "web3-providers-ipc": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "oboe": "2.1.3",
                     "underscore": "1.8.3",
-                    "web3-core-helpers": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27"
                   },
                   "dependencies": {
                     "http-https": {
@@ -21015,12 +22081,12 @@
                       "bundled": true
                     },
                     "web3-core-helpers": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "underscore": "1.8.3",
-                        "web3-eth-iban": "1.0.0-beta.22",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-eth-iban": "1.0.0-beta.27",
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {
                         "underscore": {
@@ -21028,16 +22094,16 @@
                           "bundled": true
                         },
                         "web3-eth-iban": {
-                          "version": "1.0.0-beta.22",
+                          "version": "1.0.0-beta.27",
                           "bundled": true,
                           "requires": {
                             "bn.js": "4.11.8",
-                            "web3-utils": "1.0.0-beta.22"
+                            "web3-utils": "1.0.0-beta.27"
                           },
                           "dependencies": {}
                         },
                         "web3-utils": {
-                          "version": "1.0.0-beta.22",
+                          "version": "1.0.0-beta.27",
                           "bundled": true,
                           "requires": {
                             "bn.js": "4.11.6",
@@ -21055,11 +22121,11 @@
                   }
                 },
                 "web3-providers-ws": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-core-helpers": "1.0.0-beta.22",
+                    "web3-core-helpers": "1.0.0-beta.27",
                     "websocket": "1.0.24"
                   },
                   "dependencies": {
@@ -21079,7 +22145,7 @@
                       "bundled": true
                     },
                     "nan": {
-                      "version": "2.7.0",
+                      "version": "2.8.0",
                       "bundled": true
                     },
                     "typedarray-to-buffer": {
@@ -21094,12 +22160,12 @@
                       "bundled": true
                     },
                     "web3-core-helpers": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "underscore": "1.8.3",
-                        "web3-eth-iban": "1.0.0-beta.22",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-eth-iban": "1.0.0-beta.27",
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {
                         "underscore": {
@@ -21107,16 +22173,16 @@
                           "bundled": true
                         },
                         "web3-eth-iban": {
-                          "version": "1.0.0-beta.22",
+                          "version": "1.0.0-beta.27",
                           "bundled": true,
                           "requires": {
                             "bn.js": "4.11.8",
-                            "web3-utils": "1.0.0-beta.22"
+                            "web3-utils": "1.0.0-beta.27"
                           },
                           "dependencies": {}
                         },
                         "web3-utils": {
-                          "version": "1.0.0-beta.22",
+                          "version": "1.0.0-beta.27",
                           "bundled": true,
                           "requires": {
                             "bn.js": "4.11.6",
@@ -21136,7 +22202,7 @@
                       "bundled": true,
                       "requires": {
                         "debug": "2.6.9",
-                        "nan": "2.7.0",
+                        "nan": "2.8.0",
                         "typedarray-to-buffer": "3.1.2",
                         "yaeti": "0.0.6"
                       }
@@ -21150,7 +22216,7 @@
               }
             },
             "web3-utils": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
                 "bn.js": "4.11.6",
@@ -21171,7 +22237,7 @@
                   }
                 },
                 "ajv": {
-                  "version": "5.3.0",
+                  "version": "5.5.2",
                   "bundled": true,
                   "requires": {
                     "co": "4.6.0",
@@ -21400,7 +22466,7 @@
                     "keccakjs": "0.2.1",
                     "nano-json-stream-parser": "0.1.2",
                     "servify": "0.1.12",
-                    "ws": "3.3.0",
+                    "ws": "3.3.3",
                     "xhr-request-promise": "0.1.2"
                   }
                 },
@@ -21538,7 +22604,7 @@
                   "version": "5.0.3",
                   "bundled": true,
                   "requires": {
-                    "ajv": "5.3.0",
+                    "ajv": "5.5.2",
                     "har-schema": "2.0.0"
                   }
                 },
@@ -21718,7 +22784,7 @@
                   "bundled": true
                 },
                 "nan": {
-                  "version": "2.7.0",
+                  "version": "2.8.0",
                   "bundled": true
                 },
                 "nano-json-stream-parser": {
@@ -21905,7 +22971,7 @@
                     "cors": "2.8.4",
                     "express": "4.16.2",
                     "request": "2.83.0",
-                    "xhr": "2.4.0"
+                    "xhr": "2.4.1"
                   }
                 },
                 "setprototypeof": {
@@ -21916,7 +22982,7 @@
                   "version": "1.2.0",
                   "bundled": true,
                   "requires": {
-                    "nan": "2.7.0"
+                    "nan": "2.8.0"
                   }
                 },
                 "sigmund": {
@@ -22025,7 +23091,7 @@
                   }
                 },
                 "ultron": {
-                  "version": "1.1.0",
+                  "version": "1.1.1",
                   "bundled": true
                 },
                 "underscore": {
@@ -22074,16 +23140,16 @@
                   "bundled": true
                 },
                 "ws": {
-                  "version": "3.3.0",
+                  "version": "3.3.3",
                   "bundled": true,
                   "requires": {
                     "async-limiter": "1.0.0",
                     "safe-buffer": "5.1.1",
-                    "ultron": "1.1.0"
+                    "ultron": "1.1.1"
                   }
                 },
                 "xhr": {
-                  "version": "2.4.0",
+                  "version": "2.4.1",
                   "bundled": true,
                   "requires": {
                     "global": "4.3.2",
@@ -22102,7 +23168,7 @@
                     "simple-get": "1.4.3",
                     "timed-out": "2.0.0",
                     "url-set-query": "1.0.0",
-                    "xhr": "2.4.0"
+                    "xhr": "2.4.1"
                   },
                   "dependencies": {}
                 },
@@ -22122,21 +23188,21 @@
           }
         },
         "web3-eth": {
-          "version": "1.0.0-beta.22",
+          "version": "1.0.0-beta.27",
           "bundled": true,
           "requires": {
             "underscore": "1.8.3",
-            "web3-core": "1.0.0-beta.22",
-            "web3-core-helpers": "1.0.0-beta.22",
-            "web3-core-method": "1.0.0-beta.22",
-            "web3-core-subscriptions": "1.0.0-beta.22",
-            "web3-eth-abi": "1.0.0-beta.22",
-            "web3-eth-accounts": "1.0.0-beta.22",
-            "web3-eth-contract": "1.0.0-beta.22",
-            "web3-eth-iban": "1.0.0-beta.22",
-            "web3-eth-personal": "1.0.0-beta.22",
-            "web3-net": "1.0.0-beta.22",
-            "web3-utils": "1.0.0-beta.22"
+            "web3-core": "1.0.0-beta.27",
+            "web3-core-helpers": "1.0.0-beta.27",
+            "web3-core-method": "1.0.0-beta.27",
+            "web3-core-subscriptions": "1.0.0-beta.27",
+            "web3-eth-abi": "1.0.0-beta.27",
+            "web3-eth-accounts": "1.0.0-beta.27",
+            "web3-eth-contract": "1.0.0-beta.27",
+            "web3-eth-iban": "1.0.0-beta.27",
+            "web3-eth-personal": "1.0.0-beta.27",
+            "web3-net": "1.0.0-beta.27",
+            "web3-utils": "1.0.0-beta.27"
           },
           "dependencies": {
             "underscore": {
@@ -22144,51 +23210,51 @@
               "bundled": true
             },
             "web3-core": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
-                "web3-core-helpers": "1.0.0-beta.22",
-                "web3-core-method": "1.0.0-beta.22",
-                "web3-core-requestmanager": "1.0.0-beta.22",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-core-helpers": "1.0.0-beta.27",
+                "web3-core-method": "1.0.0-beta.27",
+                "web3-core-requestmanager": "1.0.0-beta.27",
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {
                 "web3-core-helpers": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-eth-iban": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-eth-iban": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {}
                 },
                 "web3-core-method": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-core-helpers": "1.0.0-beta.22",
-                    "web3-core-promievent": "1.0.0-beta.22",
-                    "web3-core-subscriptions": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27",
+                    "web3-core-promievent": "1.0.0-beta.27",
+                    "web3-core-subscriptions": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {}
                 },
                 "web3-core-requestmanager": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-core-helpers": "1.0.0-beta.22",
-                    "web3-providers-http": "1.0.0-beta.22",
-                    "web3-providers-ipc": "1.0.0-beta.22",
-                    "web3-providers-ws": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27",
+                    "web3-providers-http": "1.0.0-beta.27",
+                    "web3-providers-ipc": "1.0.0-beta.27",
+                    "web3-providers-ws": "1.0.0-beta.27"
                   },
                   "dependencies": {}
                 },
                 "web3-utils": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bn.js": "4.11.6",
@@ -22204,12 +23270,12 @@
               }
             },
             "web3-core-helpers": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
                 "underscore": "1.8.3",
-                "web3-eth-iban": "1.0.0-beta.22",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-eth-iban": "1.0.0-beta.27",
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {
                 "underscore": {
@@ -22217,16 +23283,16 @@
                   "bundled": true
                 },
                 "web3-eth-iban": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bn.js": "4.11.8",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {}
                 },
                 "web3-utils": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bn.js": "4.11.6",
@@ -22242,14 +23308,14 @@
               }
             },
             "web3-core-method": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
                 "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.22",
-                "web3-core-promievent": "1.0.0-beta.22",
-                "web3-core-subscriptions": "1.0.0-beta.22",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-core-helpers": "1.0.0-beta.27",
+                "web3-core-promievent": "1.0.0-beta.27",
+                "web3-core-subscriptions": "1.0.0-beta.27",
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {
                 "underscore": {
@@ -22257,17 +23323,17 @@
                   "bundled": true
                 },
                 "web3-core-helpers": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-eth-iban": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-eth-iban": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {}
                 },
                 "web3-core-promievent": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bluebird": "3.3.1",
@@ -22276,17 +23342,17 @@
                   "dependencies": {}
                 },
                 "web3-core-subscriptions": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "eventemitter3": "1.1.1",
                     "underscore": "1.8.3",
-                    "web3-core-helpers": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27"
                   },
                   "dependencies": {}
                 },
                 "web3-utils": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bn.js": "4.11.6",
@@ -22302,12 +23368,12 @@
               }
             },
             "web3-core-subscriptions": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
                 "eventemitter3": "1.1.1",
                 "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.22"
+                "web3-core-helpers": "1.0.0-beta.27"
               },
               "dependencies": {
                 "eventemitter3": {
@@ -22319,25 +23385,25 @@
                   "bundled": true
                 },
                 "web3-core-helpers": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-eth-iban": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-eth-iban": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {}
                 }
               }
             },
             "web3-eth-abi": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
                 "bn.js": "4.11.6",
                 "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.22",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-core-helpers": "1.0.0-beta.27",
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {
                 "bn.js": {
@@ -22349,12 +23415,12 @@
                   "bundled": true
                 },
                 "web3-core-helpers": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-eth-iban": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-eth-iban": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {
                     "underscore": {
@@ -22362,16 +23428,16 @@
                       "bundled": true
                     },
                     "web3-eth-iban": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.8",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-utils": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.6",
@@ -22387,7 +23453,7 @@
                   }
                 },
                 "web3-utils": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bn.js": "4.11.6",
@@ -22408,7 +23474,7 @@
                       }
                     },
                     "ajv": {
-                      "version": "5.3.0",
+                      "version": "5.5.2",
                       "bundled": true,
                       "requires": {
                         "co": "4.6.0",
@@ -22637,7 +23703,7 @@
                         "keccakjs": "0.2.1",
                         "nano-json-stream-parser": "0.1.2",
                         "servify": "0.1.12",
-                        "ws": "3.3.0",
+                        "ws": "3.3.3",
                         "xhr-request-promise": "0.1.2"
                       }
                     },
@@ -22775,7 +23841,7 @@
                       "version": "5.0.3",
                       "bundled": true,
                       "requires": {
-                        "ajv": "5.3.0",
+                        "ajv": "5.5.2",
                         "har-schema": "2.0.0"
                       }
                     },
@@ -22955,7 +24021,7 @@
                       "bundled": true
                     },
                     "nan": {
-                      "version": "2.7.0",
+                      "version": "2.8.0",
                       "bundled": true
                     },
                     "nano-json-stream-parser": {
@@ -23142,7 +24208,7 @@
                         "cors": "2.8.4",
                         "express": "4.16.2",
                         "request": "2.83.0",
-                        "xhr": "2.4.0"
+                        "xhr": "2.4.1"
                       }
                     },
                     "setprototypeof": {
@@ -23153,7 +24219,7 @@
                       "version": "1.2.0",
                       "bundled": true,
                       "requires": {
-                        "nan": "2.7.0"
+                        "nan": "2.8.0"
                       }
                     },
                     "sigmund": {
@@ -23262,7 +24328,7 @@
                       }
                     },
                     "ultron": {
-                      "version": "1.1.0",
+                      "version": "1.1.1",
                       "bundled": true
                     },
                     "underscore": {
@@ -23311,16 +24377,16 @@
                       "bundled": true
                     },
                     "ws": {
-                      "version": "3.3.0",
+                      "version": "3.3.3",
                       "bundled": true,
                       "requires": {
                         "async-limiter": "1.0.0",
                         "safe-buffer": "5.1.1",
-                        "ultron": "1.1.0"
+                        "ultron": "1.1.1"
                       }
                     },
                     "xhr": {
-                      "version": "2.4.0",
+                      "version": "2.4.1",
                       "bundled": true,
                       "requires": {
                         "global": "4.3.2",
@@ -23339,7 +24405,7 @@
                         "simple-get": "1.4.3",
                         "timed-out": "2.0.0",
                         "url-set-query": "1.0.0",
-                        "xhr": "2.4.0"
+                        "xhr": "2.4.1"
                       },
                       "dependencies": {}
                     },
@@ -23359,72 +24425,28 @@
               }
             },
             "web3-eth-accounts": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
                 "bluebird": "3.3.1",
-                "eth-lib": "0.1.27",
+                "crypto-browserify": "3.12.0",
+                "eth-lib": "0.2.5",
                 "scrypt.js": "0.2.0",
                 "underscore": "1.8.3",
                 "uuid": "2.0.1",
-                "web3-core": "1.0.0-beta.22",
-                "web3-core-helpers": "1.0.0-beta.22",
-                "web3-core-method": "1.0.0-beta.22",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-core": "1.0.0-beta.27",
+                "web3-core-helpers": "1.0.0-beta.27",
+                "web3-core-method": "1.0.0-beta.27",
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {
-                "accepts": {
-                  "version": "1.3.4",
+                "asn1.js": {
+                  "version": "4.9.2",
                   "bundled": true,
                   "requires": {
-                    "mime-types": "2.1.17",
-                    "negotiator": "0.6.1"
-                  }
-                },
-                "ajv": {
-                  "version": "5.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "co": "4.6.0",
-                    "fast-deep-equal": "1.0.0",
-                    "fast-json-stable-stringify": "2.0.0",
-                    "json-schema-traverse": "0.3.1"
-                  }
-                },
-                "array-flatten": {
-                  "version": "1.1.1",
-                  "bundled": true
-                },
-                "asn1": {
-                  "version": "0.2.3",
-                  "bundled": true
-                },
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "async-limiter": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "asynckit": {
-                  "version": "0.4.0",
-                  "bundled": true
-                },
-                "aws-sign2": {
-                  "version": "0.7.0",
-                  "bundled": true
-                },
-                "aws4": {
-                  "version": "1.6.0",
-                  "bundled": true
-                },
-                "bcrypt-pbkdf": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "tweetnacl": "0.14.5"
+                    "bn.js": "4.11.8",
+                    "inherits": "2.0.3",
+                    "minimalistic-assert": "1.0.0"
                   }
                 },
                 "bluebird": {
@@ -23435,38 +24457,59 @@
                   "version": "4.11.8",
                   "bundled": true
                 },
-                "body-parser": {
-                  "version": "1.18.2",
-                  "bundled": true,
-                  "requires": {
-                    "bytes": "3.0.0",
-                    "content-type": "1.0.4",
-                    "debug": "2.6.9",
-                    "depd": "1.1.1",
-                    "http-errors": "1.6.2",
-                    "iconv-lite": "0.4.19",
-                    "on-finished": "2.3.0",
-                    "qs": "6.5.1",
-                    "raw-body": "2.3.2",
-                    "type-is": "1.6.15"
-                  }
-                },
-                "boom": {
-                  "version": "4.3.1",
-                  "bundled": true,
-                  "requires": {
-                    "hoek": "4.2.0"
-                  }
-                },
                 "brorand": {
                   "version": "1.1.0",
                   "bundled": true
                 },
-                "browserify-sha3": {
-                  "version": "0.0.1",
+                "browserify-aes": {
+                  "version": "1.1.1",
                   "bundled": true,
                   "requires": {
-                    "js-sha3": "0.3.1"
+                    "buffer-xor": "1.0.3",
+                    "cipher-base": "1.0.4",
+                    "create-hash": "1.1.3",
+                    "evp_bytestokey": "1.0.3",
+                    "inherits": "2.0.3",
+                    "safe-buffer": "5.1.1"
+                  }
+                },
+                "browserify-cipher": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "browserify-aes": "1.1.1",
+                    "browserify-des": "1.0.0",
+                    "evp_bytestokey": "1.0.3"
+                  }
+                },
+                "browserify-des": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "cipher-base": "1.0.4",
+                    "des.js": "1.0.0",
+                    "inherits": "2.0.3"
+                  }
+                },
+                "browserify-rsa": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "bn.js": "4.11.8",
+                    "randombytes": "2.0.5"
+                  }
+                },
+                "browserify-sign": {
+                  "version": "4.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "bn.js": "4.11.8",
+                    "browserify-rsa": "4.0.1",
+                    "create-hash": "1.1.3",
+                    "create-hmac": "1.1.6",
+                    "elliptic": "6.4.0",
+                    "inherits": "2.0.3",
+                    "parse-asn1": "5.1.0"
                   }
                 },
                 "buffer-to-arraybuffer": {
@@ -23476,12 +24519,8 @@
                     "tape": "3.6.1"
                   }
                 },
-                "bytes": {
-                  "version": "3.0.0",
-                  "bundled": true
-                },
-                "caseless": {
-                  "version": "0.12.0",
+                "buffer-xor": {
+                  "version": "1.0.3",
                   "bundled": true
                 },
                 "cipher-base": {
@@ -23492,43 +24531,12 @@
                     "safe-buffer": "5.1.1"
                   }
                 },
-                "co": {
-                  "version": "4.6.0",
-                  "bundled": true
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
+                "create-ecdh": {
+                  "version": "4.0.0",
                   "bundled": true,
                   "requires": {
-                    "delayed-stream": "1.0.0"
-                  }
-                },
-                "content-disposition": {
-                  "version": "0.5.2",
-                  "bundled": true
-                },
-                "content-type": {
-                  "version": "1.0.4",
-                  "bundled": true
-                },
-                "cookie": {
-                  "version": "0.3.1",
-                  "bundled": true
-                },
-                "cookie-signature": {
-                  "version": "1.0.6",
-                  "bundled": true
-                },
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "bundled": true
-                },
-                "cors": {
-                  "version": "2.8.4",
-                  "bundled": true,
-                  "requires": {
-                    "object-assign": "4.1.1",
-                    "vary": "1.1.2"
+                    "bn.js": "4.11.8",
+                    "elliptic": "6.4.0"
                   }
                 },
                 "create-hash": {
@@ -23553,34 +24561,21 @@
                     "sha.js": "2.4.9"
                   }
                 },
-                "cryptiles": {
-                  "version": "3.1.2",
+                "crypto-browserify": {
+                  "version": "3.12.0",
                   "bundled": true,
                   "requires": {
-                    "boom": "5.2.0"
-                  },
-                  "dependencies": {
-                    "boom": {
-                      "version": "5.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "hoek": "4.2.0"
-                      }
-                    }
-                  }
-                },
-                "dashdash": {
-                  "version": "1.14.1",
-                  "bundled": true,
-                  "requires": {
-                    "assert-plus": "1.0.0"
-                  }
-                },
-                "debug": {
-                  "version": "2.6.9",
-                  "bundled": true,
-                  "requires": {
-                    "ms": "2.0.0"
+                    "browserify-cipher": "1.0.0",
+                    "browserify-sign": "4.0.4",
+                    "create-ecdh": "4.0.0",
+                    "create-hash": "1.1.3",
+                    "create-hmac": "1.1.6",
+                    "diffie-hellman": "5.0.2",
+                    "inherits": "2.0.3",
+                    "pbkdf2": "3.0.14",
+                    "public-encrypt": "4.0.0",
+                    "randombytes": "2.0.5",
+                    "randomfill": "1.0.3"
                   }
                 },
                 "deep-equal": {
@@ -23591,32 +24586,25 @@
                   "version": "0.0.0",
                   "bundled": true
                 },
-                "delayed-stream": {
+                "des.js": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3",
+                    "minimalistic-assert": "1.0.0"
+                  }
                 },
-                "depd": {
-                  "version": "1.1.1",
-                  "bundled": true
-                },
-                "destroy": {
-                  "version": "1.0.4",
-                  "bundled": true
+                "diffie-hellman": {
+                  "version": "5.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "bn.js": "4.11.8",
+                    "miller-rabin": "4.0.1",
+                    "randombytes": "2.0.5"
+                  }
                 },
                 "dom-walk": {
                   "version": "0.1.1",
-                  "bundled": true
-                },
-                "ecc-jsbn": {
-                  "version": "0.1.1",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "jsbn": "0.1.1"
-                  }
-                },
-                "ee-first": {
-                  "version": "1.1.1",
                   "bundled": true
                 },
                 "elliptic": {
@@ -23632,110 +24620,21 @@
                     "minimalistic-crypto-utils": "1.0.1"
                   }
                 },
-                "encodeurl": {
-                  "version": "1.0.1",
-                  "bundled": true
-                },
-                "escape-html": {
-                  "version": "1.0.3",
-                  "bundled": true
-                },
-                "etag": {
-                  "version": "1.8.1",
-                  "bundled": true
-                },
                 "eth-lib": {
-                  "version": "0.1.27",
+                  "version": "0.2.5",
                   "bundled": true,
                   "requires": {
                     "bn.js": "4.11.8",
                     "elliptic": "6.4.0",
-                    "keccakjs": "0.2.1",
-                    "nano-json-stream-parser": "0.1.2",
-                    "servify": "0.1.12",
-                    "ws": "3.3.0",
                     "xhr-request-promise": "0.1.2"
                   }
                 },
-                "express": {
-                  "version": "4.16.2",
+                "evp_bytestokey": {
+                  "version": "1.0.3",
                   "bundled": true,
                   "requires": {
-                    "accepts": "1.3.4",
-                    "array-flatten": "1.1.1",
-                    "body-parser": "1.18.2",
-                    "content-disposition": "0.5.2",
-                    "content-type": "1.0.4",
-                    "cookie": "0.3.1",
-                    "cookie-signature": "1.0.6",
-                    "debug": "2.6.9",
-                    "depd": "1.1.1",
-                    "encodeurl": "1.0.1",
-                    "escape-html": "1.0.3",
-                    "etag": "1.8.1",
-                    "finalhandler": "1.1.0",
-                    "fresh": "0.5.2",
-                    "merge-descriptors": "1.0.1",
-                    "methods": "1.1.2",
-                    "on-finished": "2.3.0",
-                    "parseurl": "1.3.2",
-                    "path-to-regexp": "0.1.7",
-                    "proxy-addr": "2.0.2",
-                    "qs": "6.5.1",
-                    "range-parser": "1.2.0",
-                    "safe-buffer": "5.1.1",
-                    "send": "0.16.1",
-                    "serve-static": "1.13.1",
-                    "setprototypeof": "1.1.0",
-                    "statuses": "1.3.1",
-                    "type-is": "1.6.15",
-                    "utils-merge": "1.0.1",
-                    "vary": "1.1.2"
-                  },
-                  "dependencies": {
-                    "setprototypeof": {
-                      "version": "1.1.0",
-                      "bundled": true
-                    },
-                    "statuses": {
-                      "version": "1.3.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "extend": {
-                  "version": "3.0.1",
-                  "bundled": true
-                },
-                "extsprintf": {
-                  "version": "1.3.0",
-                  "bundled": true
-                },
-                "fast-deep-equal": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "fast-json-stable-stringify": {
-                  "version": "2.0.0",
-                  "bundled": true
-                },
-                "finalhandler": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "debug": "2.6.9",
-                    "encodeurl": "1.0.1",
-                    "escape-html": "1.0.3",
-                    "on-finished": "2.3.0",
-                    "parseurl": "1.3.2",
-                    "statuses": "1.3.1",
-                    "unpipe": "1.0.0"
-                  },
-                  "dependencies": {
-                    "statuses": {
-                      "version": "1.3.1",
-                      "bundled": true
-                    }
+                    "md5.js": "1.3.4",
+                    "safe-buffer": "5.1.1"
                   }
                 },
                 "for-each": {
@@ -23743,34 +24642,6 @@
                   "bundled": true,
                   "requires": {
                     "is-function": "1.0.1"
-                  }
-                },
-                "forever-agent": {
-                  "version": "0.6.1",
-                  "bundled": true
-                },
-                "form-data": {
-                  "version": "2.3.1",
-                  "bundled": true,
-                  "requires": {
-                    "asynckit": "0.4.0",
-                    "combined-stream": "1.0.5",
-                    "mime-types": "2.1.17"
-                  }
-                },
-                "forwarded": {
-                  "version": "0.1.2",
-                  "bundled": true
-                },
-                "fresh": {
-                  "version": "0.5.2",
-                  "bundled": true
-                },
-                "getpass": {
-                  "version": "0.1.7",
-                  "bundled": true,
-                  "requires": {
-                    "assert-plus": "1.0.0"
                   }
                 },
                 "glob": {
@@ -23789,18 +24660,6 @@
                     "process": "0.5.2"
                   }
                 },
-                "har-schema": {
-                  "version": "2.0.0",
-                  "bundled": true
-                },
-                "har-validator": {
-                  "version": "5.0.3",
-                  "bundled": true,
-                  "requires": {
-                    "ajv": "5.3.0",
-                    "har-schema": "2.0.0"
-                  }
-                },
                 "hash-base": {
                   "version": "2.0.2",
                   "bundled": true,
@@ -23816,16 +24675,6 @@
                     "minimalistic-assert": "1.0.0"
                   }
                 },
-                "hawk": {
-                  "version": "6.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "boom": "4.3.1",
-                    "cryptiles": "3.1.2",
-                    "hoek": "4.2.0",
-                    "sntp": "2.1.0"
-                  }
-                },
                 "hmac-drbg": {
                   "version": "1.0.1",
                   "bundled": true,
@@ -23835,121 +24684,42 @@
                     "minimalistic-crypto-utils": "1.0.1"
                   }
                 },
-                "hoek": {
-                  "version": "4.2.0",
-                  "bundled": true
-                },
-                "http-errors": {
-                  "version": "1.6.2",
-                  "bundled": true,
-                  "requires": {
-                    "depd": "1.1.1",
-                    "inherits": "2.0.3",
-                    "setprototypeof": "1.0.3",
-                    "statuses": "1.4.0"
-                  }
-                },
-                "http-signature": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "assert-plus": "1.0.0",
-                    "jsprim": "1.4.1",
-                    "sshpk": "1.13.1"
-                  }
-                },
-                "iconv-lite": {
-                  "version": "0.4.19",
-                  "bundled": true
-                },
                 "inherits": {
                   "version": "2.0.3",
-                  "bundled": true
-                },
-                "ipaddr.js": {
-                  "version": "1.5.2",
                   "bundled": true
                 },
                 "is-function": {
                   "version": "1.0.1",
                   "bundled": true
                 },
-                "is-typedarray": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "bundled": true
-                },
-                "js-sha3": {
-                  "version": "0.3.1",
-                  "bundled": true
-                },
-                "jsbn": {
-                  "version": "0.1.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "json-schema": {
-                  "version": "0.2.3",
-                  "bundled": true
-                },
-                "json-schema-traverse": {
-                  "version": "0.3.1",
-                  "bundled": true
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "bundled": true
-                },
-                "jsprim": {
-                  "version": "1.4.1",
-                  "bundled": true,
-                  "requires": {
-                    "assert-plus": "1.0.0",
-                    "extsprintf": "1.3.0",
-                    "json-schema": "0.2.3",
-                    "verror": "1.10.0"
-                  }
-                },
-                "keccakjs": {
-                  "version": "0.2.1",
-                  "bundled": true,
-                  "requires": {
-                    "browserify-sha3": "0.0.1",
-                    "sha3": "1.2.0"
-                  }
-                },
                 "lru-cache": {
                   "version": "2.7.3",
                   "bundled": true
                 },
-                "media-typer": {
-                  "version": "0.3.0",
-                  "bundled": true
-                },
-                "merge-descriptors": {
-                  "version": "1.0.1",
-                  "bundled": true
-                },
-                "methods": {
-                  "version": "1.1.2",
-                  "bundled": true
-                },
-                "mime": {
-                  "version": "1.4.1",
-                  "bundled": true
-                },
-                "mime-db": {
-                  "version": "1.30.0",
-                  "bundled": true
-                },
-                "mime-types": {
-                  "version": "2.1.17",
+                "md5.js": {
+                  "version": "1.3.4",
                   "bundled": true,
                   "requires": {
-                    "mime-db": "1.30.0"
+                    "hash-base": "3.0.4",
+                    "inherits": "2.0.3"
+                  },
+                  "dependencies": {
+                    "hash-base": {
+                      "version": "3.0.4",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "safe-buffer": "5.1.1"
+                      }
+                    }
+                  }
+                },
+                "miller-rabin": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "bn.js": "4.11.8",
+                    "brorand": "1.1.0"
                   }
                 },
                 "min-document": {
@@ -23975,46 +24745,34 @@
                     "sigmund": "1.0.1"
                   }
                 },
-                "ms": {
-                  "version": "2.0.0",
-                  "bundled": true
-                },
                 "nan": {
-                  "version": "2.7.0",
-                  "bundled": true
-                },
-                "nano-json-stream-parser": {
-                  "version": "0.1.2",
-                  "bundled": true
-                },
-                "negotiator": {
-                  "version": "0.6.1",
-                  "bundled": true
-                },
-                "oauth-sign": {
-                  "version": "0.8.2",
+                  "version": "2.8.0",
                   "bundled": true
                 },
                 "object-assign": {
-                  "version": "4.1.1",
+                  "version": "3.0.0",
                   "bundled": true
                 },
                 "object-inspect": {
                   "version": "0.4.0",
                   "bundled": true
                 },
-                "on-finished": {
-                  "version": "2.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "ee-first": "1.1.1"
-                  }
-                },
                 "once": {
                   "version": "1.4.0",
                   "bundled": true,
                   "requires": {
                     "wrappy": "1.0.2"
+                  }
+                },
+                "parse-asn1": {
+                  "version": "5.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "asn1.js": "4.9.2",
+                    "browserify-aes": "1.1.1",
+                    "create-hash": "1.1.3",
+                    "evp_bytestokey": "1.0.3",
+                    "pbkdf2": "3.0.14"
                   }
                 },
                 "parse-headers": {
@@ -24024,14 +24782,6 @@
                     "for-each": "0.3.2",
                     "trim": "0.0.1"
                   }
-                },
-                "parseurl": {
-                  "version": "1.3.2",
-                  "bundled": true
-                },
-                "path-to-regexp": {
-                  "version": "0.1.7",
-                  "bundled": true
                 },
                 "pbkdf2": {
                   "version": "3.0.14",
@@ -24044,29 +24794,20 @@
                     "sha.js": "2.4.9"
                   }
                 },
-                "performance-now": {
-                  "version": "2.1.0",
-                  "bundled": true
-                },
                 "process": {
                   "version": "0.5.2",
                   "bundled": true
                 },
-                "proxy-addr": {
-                  "version": "2.0.2",
+                "public-encrypt": {
+                  "version": "4.0.0",
                   "bundled": true,
                   "requires": {
-                    "forwarded": "0.1.2",
-                    "ipaddr.js": "1.5.2"
+                    "bn.js": "4.11.8",
+                    "browserify-rsa": "4.0.1",
+                    "create-hash": "1.1.3",
+                    "parse-asn1": "5.1.0",
+                    "randombytes": "2.0.5"
                   }
-                },
-                "punycode": {
-                  "version": "1.4.1",
-                  "bundled": true
-                },
-                "qs": {
-                  "version": "6.5.1",
-                  "bundled": true
                 },
                 "query-string": {
                   "version": "2.4.2",
@@ -24075,52 +24816,19 @@
                     "strict-uri-encode": "1.1.0"
                   }
                 },
-                "range-parser": {
-                  "version": "1.2.0",
-                  "bundled": true
-                },
-                "raw-body": {
-                  "version": "2.3.2",
+                "randombytes": {
+                  "version": "2.0.5",
                   "bundled": true,
                   "requires": {
-                    "bytes": "3.0.0",
-                    "http-errors": "1.6.2",
-                    "iconv-lite": "0.4.19",
-                    "unpipe": "1.0.0"
+                    "safe-buffer": "5.1.1"
                   }
                 },
-                "request": {
-                  "version": "2.83.0",
+                "randomfill": {
+                  "version": "1.0.3",
                   "bundled": true,
                   "requires": {
-                    "aws-sign2": "0.7.0",
-                    "aws4": "1.6.0",
-                    "caseless": "0.12.0",
-                    "combined-stream": "1.0.5",
-                    "extend": "3.0.1",
-                    "forever-agent": "0.6.1",
-                    "form-data": "2.3.1",
-                    "har-validator": "5.0.3",
-                    "hawk": "6.0.2",
-                    "http-signature": "1.2.0",
-                    "is-typedarray": "1.0.0",
-                    "isstream": "0.1.2",
-                    "json-stringify-safe": "5.0.1",
-                    "mime-types": "2.1.17",
-                    "oauth-sign": "0.8.2",
-                    "performance-now": "2.1.0",
-                    "qs": "6.5.1",
-                    "safe-buffer": "5.1.1",
-                    "stringstream": "0.0.5",
-                    "tough-cookie": "2.3.3",
-                    "tunnel-agent": "0.6.0",
-                    "uuid": "3.1.0"
-                  },
-                  "dependencies": {
-                    "uuid": {
-                      "version": "3.1.0",
-                      "bundled": true
-                    }
+                    "randombytes": "2.0.5",
+                    "safe-buffer": "5.1.1"
                   }
                 },
                 "resumer": {
@@ -24146,7 +24854,7 @@
                   "version": "6.0.3",
                   "bundled": true,
                   "requires": {
-                    "nan": "2.7.0"
+                    "nan": "2.8.0"
                   }
                 },
                 "scrypt.js": {
@@ -24164,69 +24872,12 @@
                     "pbkdf2": "3.0.14"
                   }
                 },
-                "send": {
-                  "version": "0.16.1",
-                  "bundled": true,
-                  "requires": {
-                    "debug": "2.6.9",
-                    "depd": "1.1.1",
-                    "destroy": "1.0.4",
-                    "encodeurl": "1.0.1",
-                    "escape-html": "1.0.3",
-                    "etag": "1.8.1",
-                    "fresh": "0.5.2",
-                    "http-errors": "1.6.2",
-                    "mime": "1.4.1",
-                    "ms": "2.0.0",
-                    "on-finished": "2.3.0",
-                    "range-parser": "1.2.0",
-                    "statuses": "1.3.1"
-                  },
-                  "dependencies": {
-                    "statuses": {
-                      "version": "1.3.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "serve-static": {
-                  "version": "1.13.1",
-                  "bundled": true,
-                  "requires": {
-                    "encodeurl": "1.0.1",
-                    "escape-html": "1.0.3",
-                    "parseurl": "1.3.2",
-                    "send": "0.16.1"
-                  }
-                },
-                "servify": {
-                  "version": "0.1.12",
-                  "bundled": true,
-                  "requires": {
-                    "body-parser": "1.18.2",
-                    "cors": "2.8.4",
-                    "express": "4.16.2",
-                    "request": "2.83.0",
-                    "xhr": "2.4.0"
-                  }
-                },
-                "setprototypeof": {
-                  "version": "1.0.3",
-                  "bundled": true
-                },
                 "sha.js": {
                   "version": "2.4.9",
                   "bundled": true,
                   "requires": {
                     "inherits": "2.0.3",
                     "safe-buffer": "5.1.1"
-                  }
-                },
-                "sha3": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "nan": "2.7.0"
                   }
                 },
                 "sigmund": {
@@ -24242,37 +24893,8 @@
                     "xtend": "4.0.1"
                   }
                 },
-                "sntp": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "hoek": "4.2.0"
-                  }
-                },
-                "sshpk": {
-                  "version": "1.13.1",
-                  "bundled": true,
-                  "requires": {
-                    "asn1": "0.2.3",
-                    "assert-plus": "1.0.0",
-                    "bcrypt-pbkdf": "1.0.1",
-                    "dashdash": "1.14.1",
-                    "ecc-jsbn": "0.1.1",
-                    "getpass": "0.1.7",
-                    "jsbn": "0.1.1",
-                    "tweetnacl": "0.14.5"
-                  }
-                },
-                "statuses": {
-                  "version": "1.4.0",
-                  "bundled": true
-                },
                 "strict-uri-encode": {
                   "version": "1.1.0",
-                  "bundled": true
-                },
-                "stringstream": {
-                  "version": "0.0.5",
                   "bundled": true
                 },
                 "tape": {
@@ -24296,47 +24918,12 @@
                   "version": "2.0.0",
                   "bundled": true
                 },
-                "tough-cookie": {
-                  "version": "2.3.3",
-                  "bundled": true,
-                  "requires": {
-                    "punycode": "1.4.1"
-                  }
-                },
                 "trim": {
                   "version": "0.0.1",
                   "bundled": true
                 },
-                "tunnel-agent": {
-                  "version": "0.6.0",
-                  "bundled": true,
-                  "requires": {
-                    "safe-buffer": "5.1.1"
-                  }
-                },
-                "tweetnacl": {
-                  "version": "0.14.5",
-                  "bundled": true,
-                  "optional": true
-                },
-                "type-is": {
-                  "version": "1.6.15",
-                  "bundled": true,
-                  "requires": {
-                    "media-typer": "0.3.0",
-                    "mime-types": "2.1.17"
-                  }
-                },
-                "ultron": {
-                  "version": "1.1.0",
-                  "bundled": true
-                },
                 "underscore": {
                   "version": "1.8.3",
-                  "bundled": true
-                },
-                "unpipe": {
-                  "version": "1.0.0",
                   "bundled": true
                 },
                 "unzip-response": {
@@ -24347,73 +24934,56 @@
                   "version": "1.0.0",
                   "bundled": true
                 },
-                "utils-merge": {
-                  "version": "1.0.1",
-                  "bundled": true
-                },
                 "uuid": {
                   "version": "2.0.1",
                   "bundled": true
                 },
-                "vary": {
-                  "version": "1.1.2",
-                  "bundled": true
-                },
-                "verror": {
-                  "version": "1.10.0",
-                  "bundled": true,
-                  "requires": {
-                    "assert-plus": "1.0.0",
-                    "core-util-is": "1.0.2",
-                    "extsprintf": "1.3.0"
-                  }
-                },
                 "web3-core": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
-                    "web3-core-helpers": "1.0.0-beta.22",
-                    "web3-core-method": "1.0.0-beta.22",
-                    "web3-core-requestmanager": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27",
+                    "web3-core-method": "1.0.0-beta.27",
+                    "web3-core-requestmanager": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {
                     "web3-core-helpers": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "underscore": "1.8.3",
-                        "web3-eth-iban": "1.0.0-beta.22",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-eth-iban": "1.0.0-beta.27",
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-core-method": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "underscore": "1.8.3",
-                        "web3-core-helpers": "1.0.0-beta.22",
-                        "web3-core-promievent": "1.0.0-beta.22",
-                        "web3-core-subscriptions": "1.0.0-beta.22",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-core-helpers": "1.0.0-beta.27",
+                        "web3-core-promievent": "1.0.0-beta.27",
+                        "web3-core-subscriptions": "1.0.0-beta.27",
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-core-requestmanager": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "underscore": "1.8.3",
-                        "web3-core-helpers": "1.0.0-beta.22",
-                        "web3-providers-http": "1.0.0-beta.22",
-                        "web3-providers-ipc": "1.0.0-beta.22",
-                        "web3-providers-ws": "1.0.0-beta.22"
+                        "web3-core-helpers": "1.0.0-beta.27",
+                        "web3-providers-http": "1.0.0-beta.27",
+                        "web3-providers-ipc": "1.0.0-beta.27",
+                        "web3-providers-ws": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-utils": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.6",
@@ -24429,12 +24999,12 @@
                   }
                 },
                 "web3-core-helpers": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-eth-iban": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-eth-iban": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {
                     "underscore": {
@@ -24442,16 +25012,16 @@
                       "bundled": true
                     },
                     "web3-eth-iban": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.8",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-utils": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.6",
@@ -24467,14 +25037,14 @@
                   }
                 },
                 "web3-core-method": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-core-helpers": "1.0.0-beta.22",
-                    "web3-core-promievent": "1.0.0-beta.22",
-                    "web3-core-subscriptions": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27",
+                    "web3-core-promievent": "1.0.0-beta.27",
+                    "web3-core-subscriptions": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {
                     "underscore": {
@@ -24482,17 +25052,17 @@
                       "bundled": true
                     },
                     "web3-core-helpers": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "underscore": "1.8.3",
-                        "web3-eth-iban": "1.0.0-beta.22",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-eth-iban": "1.0.0-beta.27",
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-core-promievent": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bluebird": "3.3.1",
@@ -24501,17 +25071,17 @@
                       "dependencies": {}
                     },
                     "web3-core-subscriptions": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "eventemitter3": "1.1.1",
                         "underscore": "1.8.3",
-                        "web3-core-helpers": "1.0.0-beta.22"
+                        "web3-core-helpers": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-utils": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.6",
@@ -24527,7 +25097,7 @@
                   }
                 },
                 "web3-utils": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bn.js": "4.11.6",
@@ -24548,7 +25118,7 @@
                       }
                     },
                     "ajv": {
-                      "version": "5.3.0",
+                      "version": "5.5.2",
                       "bundled": true,
                       "requires": {
                         "co": "4.6.0",
@@ -24777,7 +25347,7 @@
                         "keccakjs": "0.2.1",
                         "nano-json-stream-parser": "0.1.2",
                         "servify": "0.1.12",
-                        "ws": "3.3.0",
+                        "ws": "3.3.3",
                         "xhr-request-promise": "0.1.2"
                       }
                     },
@@ -24915,7 +25485,7 @@
                       "version": "5.0.3",
                       "bundled": true,
                       "requires": {
-                        "ajv": "5.3.0",
+                        "ajv": "5.5.2",
                         "har-schema": "2.0.0"
                       }
                     },
@@ -25095,7 +25665,7 @@
                       "bundled": true
                     },
                     "nan": {
-                      "version": "2.7.0",
+                      "version": "2.8.0",
                       "bundled": true
                     },
                     "nano-json-stream-parser": {
@@ -25282,7 +25852,7 @@
                         "cors": "2.8.4",
                         "express": "4.16.2",
                         "request": "2.83.0",
-                        "xhr": "2.4.0"
+                        "xhr": "2.4.1"
                       }
                     },
                     "setprototypeof": {
@@ -25293,7 +25863,7 @@
                       "version": "1.2.0",
                       "bundled": true,
                       "requires": {
-                        "nan": "2.7.0"
+                        "nan": "2.8.0"
                       }
                     },
                     "sigmund": {
@@ -25402,7 +25972,7 @@
                       }
                     },
                     "ultron": {
-                      "version": "1.1.0",
+                      "version": "1.1.1",
                       "bundled": true
                     },
                     "underscore": {
@@ -25451,16 +26021,16 @@
                       "bundled": true
                     },
                     "ws": {
-                      "version": "3.3.0",
+                      "version": "3.3.3",
                       "bundled": true,
                       "requires": {
                         "async-limiter": "1.0.0",
                         "safe-buffer": "5.1.1",
-                        "ultron": "1.1.0"
+                        "ultron": "1.1.1"
                       }
                     },
                     "xhr": {
-                      "version": "2.4.0",
+                      "version": "2.4.1",
                       "bundled": true,
                       "requires": {
                         "global": "4.3.2",
@@ -25479,7 +26049,7 @@
                         "simple-get": "1.4.3",
                         "timed-out": "2.0.0",
                         "url-set-query": "1.0.0",
-                        "xhr": "2.4.0"
+                        "xhr": "2.4.1"
                       },
                       "dependencies": {}
                     },
@@ -25500,17 +26070,8 @@
                   "version": "1.0.2",
                   "bundled": true
                 },
-                "ws": {
-                  "version": "3.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "async-limiter": "1.0.0",
-                    "safe-buffer": "5.1.1",
-                    "ultron": "1.1.0"
-                  }
-                },
                 "xhr": {
-                  "version": "2.4.0",
+                  "version": "2.4.1",
                   "bundled": true,
                   "requires": {
                     "global": "4.3.2",
@@ -25529,13 +26090,7 @@
                     "simple-get": "1.4.3",
                     "timed-out": "2.0.0",
                     "url-set-query": "1.0.0",
-                    "xhr": "2.4.0"
-                  },
-                  "dependencies": {
-                    "object-assign": {
-                      "version": "3.0.0",
-                      "bundled": true
-                    }
+                    "xhr": "2.4.1"
                   }
                 },
                 "xhr-request-promise": {
@@ -25552,17 +26107,17 @@
               }
             },
             "web3-eth-contract": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
                 "underscore": "1.8.3",
-                "web3-core": "1.0.0-beta.22",
-                "web3-core-helpers": "1.0.0-beta.22",
-                "web3-core-method": "1.0.0-beta.22",
-                "web3-core-promievent": "1.0.0-beta.22",
-                "web3-core-subscriptions": "1.0.0-beta.22",
-                "web3-eth-abi": "1.0.0-beta.22",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-core": "1.0.0-beta.27",
+                "web3-core-helpers": "1.0.0-beta.27",
+                "web3-core-method": "1.0.0-beta.27",
+                "web3-core-promievent": "1.0.0-beta.27",
+                "web3-core-subscriptions": "1.0.0-beta.27",
+                "web3-eth-abi": "1.0.0-beta.27",
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {
                 "underscore": {
@@ -25570,51 +26125,51 @@
                   "bundled": true
                 },
                 "web3-core": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
-                    "web3-core-helpers": "1.0.0-beta.22",
-                    "web3-core-method": "1.0.0-beta.22",
-                    "web3-core-requestmanager": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27",
+                    "web3-core-method": "1.0.0-beta.27",
+                    "web3-core-requestmanager": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {
                     "web3-core-helpers": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "underscore": "1.8.3",
-                        "web3-eth-iban": "1.0.0-beta.22",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-eth-iban": "1.0.0-beta.27",
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-core-method": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "underscore": "1.8.3",
-                        "web3-core-helpers": "1.0.0-beta.22",
-                        "web3-core-promievent": "1.0.0-beta.22",
-                        "web3-core-subscriptions": "1.0.0-beta.22",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-core-helpers": "1.0.0-beta.27",
+                        "web3-core-promievent": "1.0.0-beta.27",
+                        "web3-core-subscriptions": "1.0.0-beta.27",
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-core-requestmanager": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "underscore": "1.8.3",
-                        "web3-core-helpers": "1.0.0-beta.22",
-                        "web3-providers-http": "1.0.0-beta.22",
-                        "web3-providers-ipc": "1.0.0-beta.22",
-                        "web3-providers-ws": "1.0.0-beta.22"
+                        "web3-core-helpers": "1.0.0-beta.27",
+                        "web3-providers-http": "1.0.0-beta.27",
+                        "web3-providers-ipc": "1.0.0-beta.27",
+                        "web3-providers-ws": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-utils": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.6",
@@ -25630,12 +26185,12 @@
                   }
                 },
                 "web3-core-helpers": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-eth-iban": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-eth-iban": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {
                     "underscore": {
@@ -25643,16 +26198,16 @@
                       "bundled": true
                     },
                     "web3-eth-iban": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.8",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-utils": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.6",
@@ -25668,14 +26223,14 @@
                   }
                 },
                 "web3-core-method": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-core-helpers": "1.0.0-beta.22",
-                    "web3-core-promievent": "1.0.0-beta.22",
-                    "web3-core-subscriptions": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27",
+                    "web3-core-promievent": "1.0.0-beta.27",
+                    "web3-core-subscriptions": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {
                     "underscore": {
@@ -25683,17 +26238,17 @@
                       "bundled": true
                     },
                     "web3-core-helpers": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "underscore": "1.8.3",
-                        "web3-eth-iban": "1.0.0-beta.22",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-eth-iban": "1.0.0-beta.27",
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-core-promievent": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bluebird": "3.3.1",
@@ -25702,17 +26257,17 @@
                       "dependencies": {}
                     },
                     "web3-core-subscriptions": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "eventemitter3": "1.1.1",
                         "underscore": "1.8.3",
-                        "web3-core-helpers": "1.0.0-beta.22"
+                        "web3-core-helpers": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-utils": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.6",
@@ -25728,7 +26283,7 @@
                   }
                 },
                 "web3-core-promievent": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bluebird": "3.3.1",
@@ -25746,12 +26301,12 @@
                   }
                 },
                 "web3-core-subscriptions": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "eventemitter3": "1.1.1",
                     "underscore": "1.8.3",
-                    "web3-core-helpers": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27"
                   },
                   "dependencies": {
                     "eventemitter3": {
@@ -25763,25 +26318,25 @@
                       "bundled": true
                     },
                     "web3-core-helpers": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "underscore": "1.8.3",
-                        "web3-eth-iban": "1.0.0-beta.22",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-eth-iban": "1.0.0-beta.27",
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     }
                   }
                 },
                 "web3-eth-abi": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bn.js": "4.11.6",
                     "underscore": "1.8.3",
-                    "web3-core-helpers": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {
                     "bn.js": {
@@ -25793,17 +26348,17 @@
                       "bundled": true
                     },
                     "web3-core-helpers": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "underscore": "1.8.3",
-                        "web3-eth-iban": "1.0.0-beta.22",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-eth-iban": "1.0.0-beta.27",
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-utils": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.6",
@@ -25819,7 +26374,7 @@
                   }
                 },
                 "web3-utils": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bn.js": "4.11.6",
@@ -25840,7 +26395,7 @@
                       }
                     },
                     "ajv": {
-                      "version": "5.3.0",
+                      "version": "5.5.2",
                       "bundled": true,
                       "requires": {
                         "co": "4.6.0",
@@ -26069,7 +26624,7 @@
                         "keccakjs": "0.2.1",
                         "nano-json-stream-parser": "0.1.2",
                         "servify": "0.1.12",
-                        "ws": "3.3.0",
+                        "ws": "3.3.3",
                         "xhr-request-promise": "0.1.2"
                       }
                     },
@@ -26207,7 +26762,7 @@
                       "version": "5.0.3",
                       "bundled": true,
                       "requires": {
-                        "ajv": "5.3.0",
+                        "ajv": "5.5.2",
                         "har-schema": "2.0.0"
                       }
                     },
@@ -26387,7 +26942,7 @@
                       "bundled": true
                     },
                     "nan": {
-                      "version": "2.7.0",
+                      "version": "2.8.0",
                       "bundled": true
                     },
                     "nano-json-stream-parser": {
@@ -26574,7 +27129,7 @@
                         "cors": "2.8.4",
                         "express": "4.16.2",
                         "request": "2.83.0",
-                        "xhr": "2.4.0"
+                        "xhr": "2.4.1"
                       }
                     },
                     "setprototypeof": {
@@ -26585,7 +27140,7 @@
                       "version": "1.2.0",
                       "bundled": true,
                       "requires": {
-                        "nan": "2.7.0"
+                        "nan": "2.8.0"
                       }
                     },
                     "sigmund": {
@@ -26694,7 +27249,7 @@
                       }
                     },
                     "ultron": {
-                      "version": "1.1.0",
+                      "version": "1.1.1",
                       "bundled": true
                     },
                     "underscore": {
@@ -26743,16 +27298,16 @@
                       "bundled": true
                     },
                     "ws": {
-                      "version": "3.3.0",
+                      "version": "3.3.3",
                       "bundled": true,
                       "requires": {
                         "async-limiter": "1.0.0",
                         "safe-buffer": "5.1.1",
-                        "ultron": "1.1.0"
+                        "ultron": "1.1.1"
                       }
                     },
                     "xhr": {
-                      "version": "2.4.0",
+                      "version": "2.4.1",
                       "bundled": true,
                       "requires": {
                         "global": "4.3.2",
@@ -26771,7 +27326,7 @@
                         "simple-get": "1.4.3",
                         "timed-out": "2.0.0",
                         "url-set-query": "1.0.0",
-                        "xhr": "2.4.0"
+                        "xhr": "2.4.1"
                       },
                       "dependencies": {}
                     },
@@ -26791,11 +27346,11 @@
               }
             },
             "web3-eth-iban": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
                 "bn.js": "4.11.8",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {
                 "bn.js": {
@@ -26803,7 +27358,7 @@
                   "bundled": true
                 },
                 "web3-utils": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bn.js": "4.11.6",
@@ -26819,62 +27374,62 @@
               }
             },
             "web3-eth-personal": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
-                "web3-core": "1.0.0-beta.22",
-                "web3-core-helpers": "1.0.0-beta.22",
-                "web3-core-method": "1.0.0-beta.22",
-                "web3-net": "1.0.0-beta.22",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-core": "1.0.0-beta.27",
+                "web3-core-helpers": "1.0.0-beta.27",
+                "web3-core-method": "1.0.0-beta.27",
+                "web3-net": "1.0.0-beta.27",
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {
                 "web3-core": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
-                    "web3-core-helpers": "1.0.0-beta.22",
-                    "web3-core-method": "1.0.0-beta.22",
-                    "web3-core-requestmanager": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27",
+                    "web3-core-method": "1.0.0-beta.27",
+                    "web3-core-requestmanager": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {
                     "web3-core-helpers": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "underscore": "1.8.3",
-                        "web3-eth-iban": "1.0.0-beta.22",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-eth-iban": "1.0.0-beta.27",
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-core-method": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "underscore": "1.8.3",
-                        "web3-core-helpers": "1.0.0-beta.22",
-                        "web3-core-promievent": "1.0.0-beta.22",
-                        "web3-core-subscriptions": "1.0.0-beta.22",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-core-helpers": "1.0.0-beta.27",
+                        "web3-core-promievent": "1.0.0-beta.27",
+                        "web3-core-subscriptions": "1.0.0-beta.27",
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-core-requestmanager": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "underscore": "1.8.3",
-                        "web3-core-helpers": "1.0.0-beta.22",
-                        "web3-providers-http": "1.0.0-beta.22",
-                        "web3-providers-ipc": "1.0.0-beta.22",
-                        "web3-providers-ws": "1.0.0-beta.22"
+                        "web3-core-helpers": "1.0.0-beta.27",
+                        "web3-providers-http": "1.0.0-beta.27",
+                        "web3-providers-ipc": "1.0.0-beta.27",
+                        "web3-providers-ws": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-utils": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.6",
@@ -26890,12 +27445,12 @@
                   }
                 },
                 "web3-core-helpers": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-eth-iban": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-eth-iban": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {
                     "underscore": {
@@ -26903,16 +27458,16 @@
                       "bundled": true
                     },
                     "web3-eth-iban": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.8",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-utils": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.6",
@@ -26928,14 +27483,14 @@
                   }
                 },
                 "web3-core-method": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-core-helpers": "1.0.0-beta.22",
-                    "web3-core-promievent": "1.0.0-beta.22",
-                    "web3-core-subscriptions": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27",
+                    "web3-core-promievent": "1.0.0-beta.27",
+                    "web3-core-subscriptions": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {
                     "underscore": {
@@ -26943,17 +27498,17 @@
                       "bundled": true
                     },
                     "web3-core-helpers": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "underscore": "1.8.3",
-                        "web3-eth-iban": "1.0.0-beta.22",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-eth-iban": "1.0.0-beta.27",
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-core-promievent": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bluebird": "3.3.1",
@@ -26962,17 +27517,17 @@
                       "dependencies": {}
                     },
                     "web3-core-subscriptions": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "eventemitter3": "1.1.1",
                         "underscore": "1.8.3",
-                        "web3-core-helpers": "1.0.0-beta.22"
+                        "web3-core-helpers": "1.0.0-beta.27"
                       },
                       "dependencies": {}
                     },
                     "web3-utils": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.6",
@@ -26988,60 +27543,60 @@
                   }
                 },
                 "web3-net": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
-                    "web3-core": "1.0.0-beta.22",
-                    "web3-core-method": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-core": "1.0.0-beta.27",
+                    "web3-core-method": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {
                     "web3-core": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
-                        "web3-core-helpers": "1.0.0-beta.22",
-                        "web3-core-method": "1.0.0-beta.22",
-                        "web3-core-requestmanager": "1.0.0-beta.22",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-core-helpers": "1.0.0-beta.27",
+                        "web3-core-method": "1.0.0-beta.27",
+                        "web3-core-requestmanager": "1.0.0-beta.27",
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {
                         "web3-core-helpers": {
-                          "version": "1.0.0-beta.22",
+                          "version": "1.0.0-beta.27",
                           "bundled": true,
                           "requires": {
                             "underscore": "1.8.3",
-                            "web3-eth-iban": "1.0.0-beta.22",
-                            "web3-utils": "1.0.0-beta.22"
+                            "web3-eth-iban": "1.0.0-beta.27",
+                            "web3-utils": "1.0.0-beta.27"
                           },
                           "dependencies": {}
                         },
                         "web3-core-method": {
-                          "version": "1.0.0-beta.22",
+                          "version": "1.0.0-beta.27",
                           "bundled": true,
                           "requires": {
                             "underscore": "1.8.3",
-                            "web3-core-helpers": "1.0.0-beta.22",
-                            "web3-core-promievent": "1.0.0-beta.22",
-                            "web3-core-subscriptions": "1.0.0-beta.22",
-                            "web3-utils": "1.0.0-beta.22"
+                            "web3-core-helpers": "1.0.0-beta.27",
+                            "web3-core-promievent": "1.0.0-beta.27",
+                            "web3-core-subscriptions": "1.0.0-beta.27",
+                            "web3-utils": "1.0.0-beta.27"
                           },
                           "dependencies": {}
                         },
                         "web3-core-requestmanager": {
-                          "version": "1.0.0-beta.22",
+                          "version": "1.0.0-beta.27",
                           "bundled": true,
                           "requires": {
                             "underscore": "1.8.3",
-                            "web3-core-helpers": "1.0.0-beta.22",
-                            "web3-providers-http": "1.0.0-beta.22",
-                            "web3-providers-ipc": "1.0.0-beta.22",
-                            "web3-providers-ws": "1.0.0-beta.22"
+                            "web3-core-helpers": "1.0.0-beta.27",
+                            "web3-providers-http": "1.0.0-beta.27",
+                            "web3-providers-ipc": "1.0.0-beta.27",
+                            "web3-providers-ws": "1.0.0-beta.27"
                           },
                           "dependencies": {}
                         },
                         "web3-utils": {
-                          "version": "1.0.0-beta.22",
+                          "version": "1.0.0-beta.27",
                           "bundled": true,
                           "requires": {
                             "bn.js": "4.11.6",
@@ -27057,14 +27612,14 @@
                       }
                     },
                     "web3-core-method": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "underscore": "1.8.3",
-                        "web3-core-helpers": "1.0.0-beta.22",
-                        "web3-core-promievent": "1.0.0-beta.22",
-                        "web3-core-subscriptions": "1.0.0-beta.22",
-                        "web3-utils": "1.0.0-beta.22"
+                        "web3-core-helpers": "1.0.0-beta.27",
+                        "web3-core-promievent": "1.0.0-beta.27",
+                        "web3-core-subscriptions": "1.0.0-beta.27",
+                        "web3-utils": "1.0.0-beta.27"
                       },
                       "dependencies": {
                         "underscore": {
@@ -27072,17 +27627,17 @@
                           "bundled": true
                         },
                         "web3-core-helpers": {
-                          "version": "1.0.0-beta.22",
+                          "version": "1.0.0-beta.27",
                           "bundled": true,
                           "requires": {
                             "underscore": "1.8.3",
-                            "web3-eth-iban": "1.0.0-beta.22",
-                            "web3-utils": "1.0.0-beta.22"
+                            "web3-eth-iban": "1.0.0-beta.27",
+                            "web3-utils": "1.0.0-beta.27"
                           },
                           "dependencies": {}
                         },
                         "web3-core-promievent": {
-                          "version": "1.0.0-beta.22",
+                          "version": "1.0.0-beta.27",
                           "bundled": true,
                           "requires": {
                             "bluebird": "3.3.1",
@@ -27091,17 +27646,17 @@
                           "dependencies": {}
                         },
                         "web3-core-subscriptions": {
-                          "version": "1.0.0-beta.22",
+                          "version": "1.0.0-beta.27",
                           "bundled": true,
                           "requires": {
                             "eventemitter3": "1.1.1",
                             "underscore": "1.8.3",
-                            "web3-core-helpers": "1.0.0-beta.22"
+                            "web3-core-helpers": "1.0.0-beta.27"
                           },
                           "dependencies": {}
                         },
                         "web3-utils": {
-                          "version": "1.0.0-beta.22",
+                          "version": "1.0.0-beta.27",
                           "bundled": true,
                           "requires": {
                             "bn.js": "4.11.6",
@@ -27117,7 +27672,7 @@
                       }
                     },
                     "web3-utils": {
-                      "version": "1.0.0-beta.22",
+                      "version": "1.0.0-beta.27",
                       "bundled": true,
                       "requires": {
                         "bn.js": "4.11.6",
@@ -27138,7 +27693,7 @@
                           }
                         },
                         "ajv": {
-                          "version": "5.3.0",
+                          "version": "5.5.2",
                           "bundled": true,
                           "requires": {
                             "co": "4.6.0",
@@ -27367,7 +27922,7 @@
                             "keccakjs": "0.2.1",
                             "nano-json-stream-parser": "0.1.2",
                             "servify": "0.1.12",
-                            "ws": "3.3.0",
+                            "ws": "3.3.3",
                             "xhr-request-promise": "0.1.2"
                           }
                         },
@@ -27505,7 +28060,7 @@
                           "version": "5.0.3",
                           "bundled": true,
                           "requires": {
-                            "ajv": "5.3.0",
+                            "ajv": "5.5.2",
                             "har-schema": "2.0.0"
                           }
                         },
@@ -27685,7 +28240,7 @@
                           "bundled": true
                         },
                         "nan": {
-                          "version": "2.7.0",
+                          "version": "2.8.0",
                           "bundled": true
                         },
                         "nano-json-stream-parser": {
@@ -27872,7 +28427,7 @@
                             "cors": "2.8.4",
                             "express": "4.16.2",
                             "request": "2.83.0",
-                            "xhr": "2.4.0"
+                            "xhr": "2.4.1"
                           }
                         },
                         "setprototypeof": {
@@ -27883,7 +28438,7 @@
                           "version": "1.2.0",
                           "bundled": true,
                           "requires": {
-                            "nan": "2.7.0"
+                            "nan": "2.8.0"
                           }
                         },
                         "sigmund": {
@@ -27992,7 +28547,7 @@
                           }
                         },
                         "ultron": {
-                          "version": "1.1.0",
+                          "version": "1.1.1",
                           "bundled": true
                         },
                         "underscore": {
@@ -28041,16 +28596,16 @@
                           "bundled": true
                         },
                         "ws": {
-                          "version": "3.3.0",
+                          "version": "3.3.3",
                           "bundled": true,
                           "requires": {
                             "async-limiter": "1.0.0",
                             "safe-buffer": "5.1.1",
-                            "ultron": "1.1.0"
+                            "ultron": "1.1.1"
                           }
                         },
                         "xhr": {
-                          "version": "2.4.0",
+                          "version": "2.4.1",
                           "bundled": true,
                           "requires": {
                             "global": "4.3.2",
@@ -28069,7 +28624,7 @@
                             "simple-get": "1.4.3",
                             "timed-out": "2.0.0",
                             "url-set-query": "1.0.0",
-                            "xhr": "2.4.0"
+                            "xhr": "2.4.1"
                           },
                           "dependencies": {}
                         },
@@ -28089,7 +28644,7 @@
                   }
                 },
                 "web3-utils": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bn.js": "4.11.6",
@@ -28110,7 +28665,7 @@
                       }
                     },
                     "ajv": {
-                      "version": "5.3.0",
+                      "version": "5.5.2",
                       "bundled": true,
                       "requires": {
                         "co": "4.6.0",
@@ -28339,7 +28894,7 @@
                         "keccakjs": "0.2.1",
                         "nano-json-stream-parser": "0.1.2",
                         "servify": "0.1.12",
-                        "ws": "3.3.0",
+                        "ws": "3.3.3",
                         "xhr-request-promise": "0.1.2"
                       }
                     },
@@ -28477,7 +29032,7 @@
                       "version": "5.0.3",
                       "bundled": true,
                       "requires": {
-                        "ajv": "5.3.0",
+                        "ajv": "5.5.2",
                         "har-schema": "2.0.0"
                       }
                     },
@@ -28657,7 +29212,7 @@
                       "bundled": true
                     },
                     "nan": {
-                      "version": "2.7.0",
+                      "version": "2.8.0",
                       "bundled": true
                     },
                     "nano-json-stream-parser": {
@@ -28844,7 +29399,7 @@
                         "cors": "2.8.4",
                         "express": "4.16.2",
                         "request": "2.83.0",
-                        "xhr": "2.4.0"
+                        "xhr": "2.4.1"
                       }
                     },
                     "setprototypeof": {
@@ -28855,7 +29410,7 @@
                       "version": "1.2.0",
                       "bundled": true,
                       "requires": {
-                        "nan": "2.7.0"
+                        "nan": "2.8.0"
                       }
                     },
                     "sigmund": {
@@ -28964,7 +29519,7 @@
                       }
                     },
                     "ultron": {
-                      "version": "1.1.0",
+                      "version": "1.1.1",
                       "bundled": true
                     },
                     "underscore": {
@@ -29013,16 +29568,16 @@
                       "bundled": true
                     },
                     "ws": {
-                      "version": "3.3.0",
+                      "version": "3.3.3",
                       "bundled": true,
                       "requires": {
                         "async-limiter": "1.0.0",
                         "safe-buffer": "5.1.1",
-                        "ultron": "1.1.0"
+                        "ultron": "1.1.1"
                       }
                     },
                     "xhr": {
-                      "version": "2.4.0",
+                      "version": "2.4.1",
                       "bundled": true,
                       "requires": {
                         "global": "4.3.2",
@@ -29041,7 +29596,7 @@
                         "simple-get": "1.4.3",
                         "timed-out": "2.0.0",
                         "url-set-query": "1.0.0",
-                        "xhr": "2.4.0"
+                        "xhr": "2.4.1"
                       },
                       "dependencies": {}
                     },
@@ -29061,39 +29616,39 @@
               }
             },
             "web3-net": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
-                "web3-core": "1.0.0-beta.22",
-                "web3-core-method": "1.0.0-beta.22",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-core": "1.0.0-beta.27",
+                "web3-core-method": "1.0.0-beta.27",
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {
                 "web3-core": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
-                    "web3-core-helpers": "1.0.0-beta.22",
-                    "web3-core-method": "1.0.0-beta.22",
-                    "web3-core-requestmanager": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27",
+                    "web3-core-method": "1.0.0-beta.27",
+                    "web3-core-requestmanager": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {}
                 },
                 "web3-core-method": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-core-helpers": "1.0.0-beta.22",
-                    "web3-core-promievent": "1.0.0-beta.22",
-                    "web3-core-subscriptions": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27",
+                    "web3-core-promievent": "1.0.0-beta.27",
+                    "web3-core-subscriptions": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {}
                 },
                 "web3-utils": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bn.js": "4.11.6",
@@ -29109,7 +29664,7 @@
               }
             },
             "web3-utils": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
                 "bn.js": "4.11.6",
@@ -29130,7 +29685,7 @@
                   }
                 },
                 "ajv": {
-                  "version": "5.3.0",
+                  "version": "5.5.2",
                   "bundled": true,
                   "requires": {
                     "co": "4.6.0",
@@ -29359,7 +29914,7 @@
                     "keccakjs": "0.2.1",
                     "nano-json-stream-parser": "0.1.2",
                     "servify": "0.1.12",
-                    "ws": "3.3.0",
+                    "ws": "3.3.3",
                     "xhr-request-promise": "0.1.2"
                   }
                 },
@@ -29497,7 +30052,7 @@
                   "version": "5.0.3",
                   "bundled": true,
                   "requires": {
-                    "ajv": "5.3.0",
+                    "ajv": "5.5.2",
                     "har-schema": "2.0.0"
                   }
                 },
@@ -29677,7 +30232,7 @@
                   "bundled": true
                 },
                 "nan": {
-                  "version": "2.7.0",
+                  "version": "2.8.0",
                   "bundled": true
                 },
                 "nano-json-stream-parser": {
@@ -29864,7 +30419,7 @@
                     "cors": "2.8.4",
                     "express": "4.16.2",
                     "request": "2.83.0",
-                    "xhr": "2.4.0"
+                    "xhr": "2.4.1"
                   }
                 },
                 "setprototypeof": {
@@ -29875,7 +30430,7 @@
                   "version": "1.2.0",
                   "bundled": true,
                   "requires": {
-                    "nan": "2.7.0"
+                    "nan": "2.8.0"
                   }
                 },
                 "sigmund": {
@@ -29984,7 +30539,7 @@
                   }
                 },
                 "ultron": {
-                  "version": "1.1.0",
+                  "version": "1.1.1",
                   "bundled": true
                 },
                 "underscore": {
@@ -30033,16 +30588,16 @@
                   "bundled": true
                 },
                 "ws": {
-                  "version": "3.3.0",
+                  "version": "3.3.3",
                   "bundled": true,
                   "requires": {
                     "async-limiter": "1.0.0",
                     "safe-buffer": "5.1.1",
-                    "ultron": "1.1.0"
+                    "ultron": "1.1.1"
                   }
                 },
                 "xhr": {
-                  "version": "2.4.0",
+                  "version": "2.4.1",
                   "bundled": true,
                   "requires": {
                     "global": "4.3.2",
@@ -30061,7 +30616,7 @@
                     "simple-get": "1.4.3",
                     "timed-out": "2.0.0",
                     "url-set-query": "1.0.0",
-                    "xhr": "2.4.0"
+                    "xhr": "2.4.1"
                   },
                   "dependencies": {}
                 },
@@ -30081,61 +30636,61 @@
           }
         },
         "web3-eth-personal": {
-          "version": "1.0.0-beta.22",
+          "version": "1.0.0-beta.27",
           "bundled": true,
           "requires": {
-            "web3-core": "1.0.0-beta.22",
-            "web3-core-helpers": "1.0.0-beta.22",
-            "web3-core-method": "1.0.0-beta.22",
-            "web3-net": "1.0.0-beta.22",
-            "web3-utils": "1.0.0-beta.22"
+            "web3-core": "1.0.0-beta.27",
+            "web3-core-helpers": "1.0.0-beta.27",
+            "web3-core-method": "1.0.0-beta.27",
+            "web3-net": "1.0.0-beta.27",
+            "web3-utils": "1.0.0-beta.27"
           },
           "dependencies": {
             "web3-core": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
-                "web3-core-helpers": "1.0.0-beta.22",
-                "web3-core-method": "1.0.0-beta.22",
-                "web3-core-requestmanager": "1.0.0-beta.22",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-core-helpers": "1.0.0-beta.27",
+                "web3-core-method": "1.0.0-beta.27",
+                "web3-core-requestmanager": "1.0.0-beta.27",
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {}
             },
             "web3-core-helpers": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
                 "underscore": "1.8.3",
-                "web3-eth-iban": "1.0.0-beta.22",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-eth-iban": "1.0.0-beta.27",
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {}
             },
             "web3-core-method": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
                 "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.22",
-                "web3-core-promievent": "1.0.0-beta.22",
-                "web3-core-subscriptions": "1.0.0-beta.22",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-core-helpers": "1.0.0-beta.27",
+                "web3-core-promievent": "1.0.0-beta.27",
+                "web3-core-subscriptions": "1.0.0-beta.27",
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {}
             },
             "web3-net": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
-                "web3-core": "1.0.0-beta.22",
-                "web3-core-method": "1.0.0-beta.22",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-core": "1.0.0-beta.27",
+                "web3-core-method": "1.0.0-beta.27",
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {}
             },
             "web3-utils": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
                 "bn.js": "4.11.6",
@@ -30151,39 +30706,39 @@
           }
         },
         "web3-net": {
-          "version": "1.0.0-beta.22",
+          "version": "1.0.0-beta.27",
           "bundled": true,
           "requires": {
-            "web3-core": "1.0.0-beta.22",
-            "web3-core-method": "1.0.0-beta.22",
-            "web3-utils": "1.0.0-beta.22"
+            "web3-core": "1.0.0-beta.27",
+            "web3-core-method": "1.0.0-beta.27",
+            "web3-utils": "1.0.0-beta.27"
           },
           "dependencies": {
             "web3-core": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
-                "web3-core-helpers": "1.0.0-beta.22",
-                "web3-core-method": "1.0.0-beta.22",
-                "web3-core-requestmanager": "1.0.0-beta.22",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-core-helpers": "1.0.0-beta.27",
+                "web3-core-method": "1.0.0-beta.27",
+                "web3-core-requestmanager": "1.0.0-beta.27",
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {}
             },
             "web3-core-method": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
                 "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.22",
-                "web3-core-promievent": "1.0.0-beta.22",
-                "web3-core-subscriptions": "1.0.0-beta.22",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-core-helpers": "1.0.0-beta.27",
+                "web3-core-promievent": "1.0.0-beta.27",
+                "web3-core-subscriptions": "1.0.0-beta.27",
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {}
             },
             "web3-utils": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
                 "bn.js": "4.11.6",
@@ -30199,61 +30754,61 @@
           }
         },
         "web3-shh": {
-          "version": "1.0.0-beta.22",
+          "version": "1.0.0-beta.27",
           "bundled": true,
           "requires": {
-            "web3-core": "1.0.0-beta.22",
-            "web3-core-method": "1.0.0-beta.22",
-            "web3-core-subscriptions": "1.0.0-beta.22",
-            "web3-net": "1.0.0-beta.22"
+            "web3-core": "1.0.0-beta.27",
+            "web3-core-method": "1.0.0-beta.27",
+            "web3-core-subscriptions": "1.0.0-beta.27",
+            "web3-net": "1.0.0-beta.27"
           },
           "dependencies": {
             "web3-core": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
-                "web3-core-helpers": "1.0.0-beta.22",
-                "web3-core-method": "1.0.0-beta.22",
-                "web3-core-requestmanager": "1.0.0-beta.22",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-core-helpers": "1.0.0-beta.27",
+                "web3-core-method": "1.0.0-beta.27",
+                "web3-core-requestmanager": "1.0.0-beta.27",
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {
                 "web3-core-helpers": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-eth-iban": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-eth-iban": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {}
                 },
                 "web3-core-method": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-core-helpers": "1.0.0-beta.22",
-                    "web3-core-promievent": "1.0.0-beta.22",
-                    "web3-core-subscriptions": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27",
+                    "web3-core-promievent": "1.0.0-beta.27",
+                    "web3-core-subscriptions": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {}
                 },
                 "web3-core-requestmanager": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-core-helpers": "1.0.0-beta.22",
-                    "web3-providers-http": "1.0.0-beta.22",
-                    "web3-providers-ipc": "1.0.0-beta.22",
-                    "web3-providers-ws": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27",
+                    "web3-providers-http": "1.0.0-beta.27",
+                    "web3-providers-ipc": "1.0.0-beta.27",
+                    "web3-providers-ws": "1.0.0-beta.27"
                   },
                   "dependencies": {}
                 },
                 "web3-utils": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bn.js": "4.11.6",
@@ -30269,14 +30824,14 @@
               }
             },
             "web3-core-method": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
                 "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.22",
-                "web3-core-promievent": "1.0.0-beta.22",
-                "web3-core-subscriptions": "1.0.0-beta.22",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-core-helpers": "1.0.0-beta.27",
+                "web3-core-promievent": "1.0.0-beta.27",
+                "web3-core-subscriptions": "1.0.0-beta.27",
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {
                 "underscore": {
@@ -30284,17 +30839,17 @@
                   "bundled": true
                 },
                 "web3-core-helpers": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-eth-iban": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-eth-iban": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {}
                 },
                 "web3-core-promievent": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bluebird": "3.3.1",
@@ -30303,17 +30858,17 @@
                   "dependencies": {}
                 },
                 "web3-core-subscriptions": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "eventemitter3": "1.1.1",
                     "underscore": "1.8.3",
-                    "web3-core-helpers": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27"
                   },
                   "dependencies": {}
                 },
                 "web3-utils": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bn.js": "4.11.6",
@@ -30329,12 +30884,12 @@
               }
             },
             "web3-core-subscriptions": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
                 "eventemitter3": "1.1.1",
                 "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.22"
+                "web3-core-helpers": "1.0.0-beta.27"
               },
               "dependencies": {
                 "eventemitter3": {
@@ -30346,51 +30901,51 @@
                   "bundled": true
                 },
                 "web3-core-helpers": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-eth-iban": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-eth-iban": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {}
                 }
               }
             },
             "web3-net": {
-              "version": "1.0.0-beta.22",
+              "version": "1.0.0-beta.27",
               "bundled": true,
               "requires": {
-                "web3-core": "1.0.0-beta.22",
-                "web3-core-method": "1.0.0-beta.22",
-                "web3-utils": "1.0.0-beta.22"
+                "web3-core": "1.0.0-beta.27",
+                "web3-core-method": "1.0.0-beta.27",
+                "web3-utils": "1.0.0-beta.27"
               },
               "dependencies": {
                 "web3-core": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
-                    "web3-core-helpers": "1.0.0-beta.22",
-                    "web3-core-method": "1.0.0-beta.22",
-                    "web3-core-requestmanager": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27",
+                    "web3-core-method": "1.0.0-beta.27",
+                    "web3-core-requestmanager": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {}
                 },
                 "web3-core-method": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "underscore": "1.8.3",
-                    "web3-core-helpers": "1.0.0-beta.22",
-                    "web3-core-promievent": "1.0.0-beta.22",
-                    "web3-core-subscriptions": "1.0.0-beta.22",
-                    "web3-utils": "1.0.0-beta.22"
+                    "web3-core-helpers": "1.0.0-beta.27",
+                    "web3-core-promievent": "1.0.0-beta.27",
+                    "web3-core-subscriptions": "1.0.0-beta.27",
+                    "web3-utils": "1.0.0-beta.27"
                   },
                   "dependencies": {}
                 },
                 "web3-utils": {
-                  "version": "1.0.0-beta.22",
+                  "version": "1.0.0-beta.27",
                   "bundled": true,
                   "requires": {
                     "bn.js": "4.11.6",
@@ -30408,7 +30963,7 @@
           }
         },
         "web3-utils": {
-          "version": "1.0.0-beta.22",
+          "version": "1.0.0-beta.27",
           "bundled": true,
           "requires": {
             "bn.js": "4.11.6",
@@ -30429,7 +30984,7 @@
               }
             },
             "ajv": {
-              "version": "5.3.0",
+              "version": "5.5.2",
               "bundled": true,
               "requires": {
                 "co": "4.6.0",
@@ -30658,7 +31213,7 @@
                 "keccakjs": "0.2.1",
                 "nano-json-stream-parser": "0.1.2",
                 "servify": "0.1.12",
-                "ws": "3.3.0",
+                "ws": "3.3.3",
                 "xhr-request-promise": "0.1.2"
               }
             },
@@ -30796,7 +31351,7 @@
               "version": "5.0.3",
               "bundled": true,
               "requires": {
-                "ajv": "5.3.0",
+                "ajv": "5.5.2",
                 "har-schema": "2.0.0"
               }
             },
@@ -30976,7 +31531,7 @@
               "bundled": true
             },
             "nan": {
-              "version": "2.7.0",
+              "version": "2.8.0",
               "bundled": true
             },
             "nano-json-stream-parser": {
@@ -31163,7 +31718,7 @@
                 "cors": "2.8.4",
                 "express": "4.16.2",
                 "request": "2.83.0",
-                "xhr": "2.4.0"
+                "xhr": "2.4.1"
               }
             },
             "setprototypeof": {
@@ -31174,7 +31729,7 @@
               "version": "1.2.0",
               "bundled": true,
               "requires": {
-                "nan": "2.7.0"
+                "nan": "2.8.0"
               }
             },
             "sigmund": {
@@ -31283,7 +31838,7 @@
               }
             },
             "ultron": {
-              "version": "1.1.0",
+              "version": "1.1.1",
               "bundled": true
             },
             "underscore": {
@@ -31332,16 +31887,16 @@
               "bundled": true
             },
             "ws": {
-              "version": "3.3.0",
+              "version": "3.3.3",
               "bundled": true,
               "requires": {
                 "async-limiter": "1.0.0",
                 "safe-buffer": "5.1.1",
-                "ultron": "1.1.0"
+                "ultron": "1.1.1"
               }
             },
             "xhr": {
-              "version": "2.4.0",
+              "version": "2.4.1",
               "bundled": true,
               "requires": {
                 "global": "4.3.2",
@@ -31360,7 +31915,7 @@
                 "simple-get": "1.4.3",
                 "timed-out": "2.0.0",
                 "url-set-query": "1.0.0",
-                "xhr": "2.4.0"
+                "xhr": "2.4.1"
               },
               "dependencies": {}
             },
@@ -31890,38 +32445,112 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-      "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+      "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+      "dev": true,
       "requires": {
-        "camelcase": "3.0.0",
         "cliui": "3.2.0",
         "decamelize": "1.2.0",
+        "find-up": "2.1.0",
         "get-caller-file": "1.0.2",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
+        "os-locale": "2.1.0",
         "require-directory": "2.1.1",
         "require-main-filename": "1.0.1",
         "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
         "y18n": "3.2.1",
-        "yargs-parser": "5.0.0"
+        "yargs-parser": "8.1.0"
       },
       "dependencies": {
-        "camelcase": {
+        "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
         },
         "cliui": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
           "requires": {
             "string-width": "1.0.2",
             "strip-ansi": "3.0.1",
             "wrap-ansi": "2.1.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+          "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0"
           }
         }
       }

--- a/src/components/crowdsale/utils.js
+++ b/src/components/crowdsale/utils.js
@@ -691,7 +691,7 @@ export function getPricingStrategyData (web3) {
           }
 
           console.log('pricing strategy rate:', rate)
-          crowdsalePageStore.setProperty('rate', parseInt(rate, 10))//web3.fromWei(parseInt(rate, 10), "ether");
+          crowdsalePageStore.setProperty('rate', parseInt(rate, 10))
           resolve()
         })
       })

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -386,6 +386,6 @@ export const toast = {
   }
 }
 
-export const gweiToWei = x => x * 1000000000
+export const gweiToWei = x => parseInt(x * 1000000000, 10)
 
 export const weiToGwei = x => x / 1000000000


### PR DESCRIPTION
Relates to https://github.com/poanetwork/web3.js/issues/1
**Problem**: web3 is outdated
**Solution**: get upstream from web3.js@1.0.0-beta.27 and merge