### PR TITLE
(Emergency) Mainnet is down for maintenance warning due to audit

### DIFF
--- a/src/components/stepThree/index.js
+++ b/src/components/stepThree/index.js
@@ -19,7 +19,7 @@ import {
 } from "../../utils/constants";
 import { inject, observer } from "mobx-react";
 import { Loader } from '../Common/Loader'
-import { noGasPriceAvailable, warningOnMainnetAlert } from '../../utils/alerts'
+import { noGasPriceAvailable, warningOnMainnetAlert, mainnetIsOnMaintenance } from '../../utils/alerts'
 
 const { CROWDSALE_SETUP } = NAVIGATION_STEPS;
 const { EMPTY, VALID } = VALIDATION_TYPES;
@@ -173,7 +173,8 @@ export class stepThree extends React.Component {
               }, 0)
             }
 
-            return warningOnMainnetAlert(tiersCount, priceSelected, reservedCount, whitelistCount, this.goToDeploymentStage)
+            //return warningOnMainnetAlert(tiersCount, priceSelected, reservedCount, whitelistCount, this.goToDeploymentStage)
+            return mainnetIsOnMaintenance()
           }
           this.goToDeploymentStage()
         })


### PR DESCRIPTION
Deployment to Mainnet is down for maintenance due to wizard contracts audit.