### PR TITLE
(Fix) Use eth.getAccounts() instead of eth.accounts

### DIFF
--- a/src/components/invest/index.js
+++ b/src/components/invest/index.js
@@ -177,7 +177,8 @@ export class Invest extends React.Component {
       }
 
       getCurrentRate(crowdsaleContract)
-        .then(() => this.investToTokensForWhitelistedCrowdsaleInternal(crowdsaleContract, tierNum, web3.eth.accounts))
+        .then(() => web3.eth.getAccounts())
+        .then((accounts) => this.investToTokensForWhitelistedCrowdsaleInternal(crowdsaleContract, tierNum, accounts))
         .catch(console.log)
     })
   }


### PR DESCRIPTION
The invest page doesn't seem to be working because of this.

`web3.eth.accounts` has a different behavior in web3 1.0. Not sure why this was working before.