### PR TITLE
(Refactor) Refactor RadioInputField and add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "node": "8.9.0"
   },
   "devDependencies": {
+    "enzyme": "^3.3.0",
+    "enzyme-adapter-react-15": "^1.0.5",
     "ethereumjs-testrpc": "^4.1.3",
     "ganache-cli": "^6.0.3",
     "gulp": "^3.9.1",
@@ -23,6 +25,7 @@
     "gulp-util": "^3.0.8",
     "markdown-toc": "^1.2.0",
     "mobx-react-devtools": "^4.2.15",
+    "react-test-renderer": "^15.6.2",
     "shelljs": "^0.7.8",
     "truffle": "^3.4.9",
     "yargs": "^10.0.3"

--- a/package.json
+++ b/package.json
@@ -174,7 +174,8 @@
       "js",
       "json",
       "web.jsx",
-      "jsx"
+      "jsx",
+      "node"
     ]
   },
   "babel": {

--- a/src/components/Common/RadioInputField.js
+++ b/src/components/Common/RadioInputField.js
@@ -1,51 +1,44 @@
-import React from 'react'
+import React from 'react';
 import '../../assets/stylesheets/application.css';
 
 export class RadioInputField extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      "checked1": props.defaultValue===this.props.vals[0]?true:false,
-      "checked2": props.defaultValue===this.props.vals[0]?false:true
-    }
+      checked: this.props.defaultValue || this.props.items[0].value
+    };
   }
 
-  onChange(e) {
-    console.log(e.target);
+  onChange = (e) => {
+    const item = e.target.value
     this.setState({
-      "checked1": e.target.value===this.props.vals[0]?true:false,
-      "checked2": e.target.value===this.props.vals[0]?false:true});
+      checked: item
+    });
     this.props.onChange(e);
   }
 
   render() {
-    return (<div className={this.props.side}>
-    <label className="label">{this.props.title}</label>
-    <div className="radios-inline">
-            <label className="radio-inline">
-              <input
-                type="radio"
-                checked={this.state.checked1}
-                name={this.props.name}
-                onChange={this.onChange.bind(this)}
-                value={this.props.vals[0]}
-              />
-              <span className="title">{this.props.items[0]}</span>
-            </label>
-            <label className="radio-inline">
-              <input
-                type="radio"
-                checked={this.state.checked2}
-                name={this.props.name}
-                onChange={this.onChange.bind(this)}
-                value={this.props.vals[1]}
-              />
-              <span className="title">{this.props.items[1]}</span>
-            </label>
-          </div>
-    <p className="description">
-      {this.props.description}
-    </p>
-    </div>)
+    const inputs = this.props.items
+      .map((item, index) => (
+        <label className="radio-inline" key={index}>
+          <input
+            type="radio"
+            checked={this.state.checked === item.value}
+            onChange={this.onChange}
+            value={item.value}
+          />
+          <span className="title">{item.label}</span>
+        </label>
+      ))
+
+    return (
+      <div className={this.props.extraClassName}>
+        <label className="label">{this.props.title}</label>
+        <div className="radios-inline">
+          { inputs }
+        </div>
+        <p className="description">{this.props.description}</p>
+      </div>
+    );
   }
 }

--- a/src/components/Common/RadioInputField.spec.js
+++ b/src/components/Common/RadioInputField.spec.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { RadioInputField } from './RadioInputField';
+import renderer from 'react-test-renderer';
+import Adapter from 'enzyme-adapter-react-15';
+import { configure, mount } from 'enzyme';
+
+configure({ adapter: new Adapter() })
+
+test('Should render the component', () => {
+  const component = renderer.create(
+    <RadioInputField
+      title="Some Title"
+      items={[{ label: 'Item 1', value: 'item-1' }, { label: 'Item 2', value: 'item-2' }]}
+      onChange={() => {}}
+      description="Some Description"
+    />
+  );
+
+  let tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Should render two inputs and check the first one', () => {
+  const wrapper = mount(
+    <RadioInputField
+      title="Some Title"
+      items={[{ label: 'Item 1', value: 'item-1' }, { label: 'Item 2', value: 'item-2' }]}
+      onChange={() => {}}
+      description="Some Description"
+    />
+  );
+
+  const inputs = wrapper.find('input[type="radio"]')
+  expect(inputs.length).toBe(2)
+
+  const firstInput = inputs.at(0)
+  const secondInput = inputs.at(1)
+
+  expect(firstInput.prop('checked')).toBe(true)
+  expect(secondInput.prop('checked')).toBe(false)
+})
+
+test('The onChange callback is called when an item is selected', () => {
+  const onChangeCallback = jest.fn()
+
+  const wrapper = mount(
+    <RadioInputField
+      title="Some Title"
+      items={[{ label: 'Item 1', value: 'item-1' }, { label: 'Item 2', value: 'item-2' }]}
+      onChange={onChangeCallback}
+      description="Some Description"
+    />
+  );
+
+  wrapper.find('input[type="radio"]').at(1).simulate('change')
+
+  expect(onChangeCallback).toBeCalled()
+})
+
+test('Should accept a defaultValue prop', () => {
+  const items = [{ label: 'Item 1', value: 'item-1' }, { label: 'Item 2', value: 'item-2' }]
+  const wrapper = mount(
+    <RadioInputField
+      title="Some Title"
+      items={items}
+      defaultValue={items[1].value}
+      onChange={() => {}}
+      description="Some Description"
+    />
+  );
+
+  const firstInput = wrapper.find('input[type="radio"]').at(0)
+  const secondInput = wrapper.find('input[type="radio"]').at(1)
+
+  expect(firstInput.prop('checked')).toBe(false)
+  expect(secondInput.prop('checked')).toBe(true)
+})

--- a/src/components/Common/ReservedTokensInputBlock.js
+++ b/src/components/Common/ReservedTokensInputBlock.js
@@ -156,12 +156,9 @@ export class ReservedTokensInputBlock extends React.Component {
               errorMessage="The inserted address is invalid"
             />
             <RadioInputField
-              side="reserved-tokens-input-property reserved-tokens-input-property-middle"
+              extraClassName="reserved-tokens-input-property reserved-tokens-input-property-middle"
               title={DIMENSION}
-              items={['tokens', 'percentage']}
-              vals={['tokens', 'percentage']}
-              defaultValue={this.props.reservedTokenInputStore.dim}
-              name={'reserved-tokens-dim'}
+              items={[{ label: 'tokens', value: 'tokens' }, { label: 'percentage', value: 'percentage' }]}
               onChange={e => this.updateReservedTokenInput(e, 'dim')}
               description={`Fixed amount or % of crowdsaled tokens. Will be deposited to the account after fintalization of the crowdsale. `}
             />

--- a/src/components/Common/__snapshots__/RadioInputField.spec.js.snap
+++ b/src/components/Common/__snapshots__/RadioInputField.spec.js.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Should render the component 1`] = `
+<div
+  className={undefined}
+>
+  <label
+    className="label"
+  >
+    Some Title
+  </label>
+  <div
+    className="radios-inline"
+  >
+    <label
+      className="radio-inline"
+    >
+      <input
+        checked={true}
+        onChange={[Function]}
+        type="radio"
+        value="item-1"
+      />
+      <span
+        className="title"
+      >
+        Item 1
+      </span>
+    </label>
+    <label
+      className="radio-inline"
+    >
+      <input
+        checked={false}
+        onChange={[Function]}
+        type="radio"
+        value="item-2"
+      />
+      <span
+        className="title"
+      >
+        Item 2
+      </span>
+    </label>
+  </div>
+  <p
+    className="description"
+  >
+    Some Description
+  </p>
+</div>
+`;

--- a/src/components/stepThree/CrowdsaleBlock.js
+++ b/src/components/stepThree/CrowdsaleBlock.js
@@ -61,13 +61,9 @@ export class CrowdsaleBlock extends React.Component {
               description={`Name of a tier, e.g. PrePreIco, PreICO, ICO with bonus A, ICO with bonus B, etc. We simplified that and will increment a number after each tier.`}
             />
             <RadioInputField
-              side="right"
+              extraClassName="right"
               title={ALLOWMODIFYING}
-              items={["on", "off"]}
-              vals={["on", "off"]}
-              num={num}
-              defaultValue={this.props.tierStore.tiers[num].updatable}
-              name={"crowdsale-updatable-" + num}
+              items={[{ label: 'on', value: 'on' }, { label: 'off', value: 'off' }]}
               onChange={e => this.updateTierStore(e, "updatable")}
               description={`Pandora box feature. If it's enabled, a creator of the crowdsale can modify Start time, End time, Rate, Limit after publishing.`}
             />

--- a/src/components/stepThree/index.js
+++ b/src/components/stepThree/index.js
@@ -321,14 +321,10 @@ export class stepThree extends React.Component {
             description={`Minimum amount tokens to buy. Not a minimal size of a transaction. If minCap is 1 and user bought 1 token in a previous transaction and buying 0.1 token it will allow him to buy.`}
           />
           <RadioInputField
-            side="right"
+            extraClassName="right"
             title={ENABLE_WHITELISTING}
-            items={["yes", "no"]}
-            vals={["yes", "no"]}
-            state={this.state}
-            num={0}
+            items={[{ label: 'yes', value: 'yes' }, { label: 'no', value: 'no' }]}
             defaultValue={tierStore.tiers[0].whitelistEnabled}
-            name="crowdsale-whitelistEnabled-0"
             onChange={e => this.updateWhitelistEnabled(e)}
             description={`Enables whitelisting. If disabled, anyone can participate in the crowdsale.`}
           />
@@ -364,7 +360,7 @@ export class stepThree extends React.Component {
             <div className="hidden">
               <div className="input-block-container">
                 <InputField
-                  side="left"
+                  extraClassName="left"
                   type="text"
                   title={CROWDSALE_SETUP_NAME}
                   value={tierStore.tiers[0].tier}
@@ -374,14 +370,9 @@ export class stepThree extends React.Component {
                   description={`Name of a tier, e.g. PrePreIco, PreICO, ICO with bonus A, ICO with bonus B, etc. We simplified that and will increment a number after each tier.`}
                 />
                 <RadioInputField
-                  side="right"
+                  extraClassName="right"
                   title={ALLOWMODIFYING}
-                  items={["on", "off"]}
-                  vals={["on", "off"]}
-                  state={this.state}
-                  num={0}
-                  defaultValue={tierStore.tiers[0].updatable}
-                  name="crowdsale-updatable-0"
+                  items={[{ label: 'on', value: 'on' }, { label: 'off', value: 'off' }]}
                   onChange={e => this.updateTierStore(e, "updatable", 0)}
                   description={`Pandora box feature. If it's enabled, a creator of the crowdsale can modify Start time, End time, Rate, Limit after publishing.`}
                 />

--- a/src/components/stepThree/index.js
+++ b/src/components/stepThree/index.js
@@ -360,7 +360,7 @@ export class stepThree extends React.Component {
             <div className="hidden">
               <div className="input-block-container">
                 <InputField
-                  extraClassName="left"
+                  side="left"
                   type="text"
                   title={CROWDSALE_SETUP_NAME}
                   value={tierStore.tiers[0].tier}

--- a/src/components/stepThree/index.js
+++ b/src/components/stepThree/index.js
@@ -373,6 +373,7 @@ export class stepThree extends React.Component {
                   extraClassName="right"
                   title={ALLOWMODIFYING}
                   items={[{ label: 'on', value: 'on' }, { label: 'off', value: 'off' }]}
+                  defaultValue="off"
                   onChange={e => this.updateTierStore(e, "updatable", 0)}
                   description={`Pandora box feature. If it's enabled, a creator of the crowdsale can modify Start time, End time, Rate, Limit after publishing.`}
                 />

--- a/src/utils/blockchainHelpers.spec.js
+++ b/src/utils/blockchainHelpers.spec.js
@@ -26,10 +26,10 @@ describe('blockchainHelpers', () => {
       expect(getNetWorkNameById(12648430)).toEqual('Oracles dev test');
     });
 
-    it('should return Unknown for unknown network ids', () => {
-      expect(getNetWorkNameById(5)).toEqual('Unknown');
-      expect(getNetWorkNameById(43)).toEqual('Unknown');
-      expect(getNetWorkNameById(1000)).toEqual('Unknown');
+    it('should return null for unknown network ids', () => {
+      expect(getNetWorkNameById(5)).toEqual(null);
+      expect(getNetWorkNameById(43)).toEqual(null);
+      expect(getNetWorkNameById(1000)).toEqual(null);
     })
   })
 })


### PR DESCRIPTION
Closes #442.

This PR makes RadioInputField acccept more than two options, and improves a little its code. It also adds tests for the component.

I thought about using it for the gas price selector, but that component is special because it shows an input when you select a custom gas price, so I ended up leaving it as it was.