### PR TITLE
(Fix) Updated contracts after security audit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "submodules/oracles-token-market-net-ico"]
-	path = submodules/oracles-token-market-net-ico
-	url = https://github.com/poanetwork/ico
-	branch = master
 [submodule "submodules/oracles-combine-solidity"]
 	path = submodules/oracles-combine-solidity
 	url = https://github.com/poanetwork/oracles-combine-solidity
@@ -10,3 +6,7 @@
 	path = submodules/oracles-web3-1.0
 	url = https://github.com/poanetwork/web3.js
 	branch = 1.0
+[submodule "submodules/oracles-token-market-net-ico"]
+	path = submodules/oracles-token-market-net-ico
+	url = https://github.com/poanetwork/ico
+	branch = wizard

--- a/package-lock.json
+++ b/package-lock.json
@@ -2952,8 +2952,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decomment": {
       "version": "0.9.1",
@@ -9624,6 +9623,17 @@
         "prepend-http": "1.0.4",
         "query-string": "4.3.4",
         "sort-keys": "1.1.2"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+          "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+          "requires": {
+            "object-assign": "4.1.1",
+            "strict-uri-encode": "1.1.0"
+          }
+        }
       }
     },
     "npm-run-path": {
@@ -11615,10 +11625,11 @@
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "query-string": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.0.1.tgz",
+      "integrity": "sha512-aM+MkQClojlNiKkO09tiN2Fv8jM/L7GWIjG2liWeKljlOdOPNWr+bW3KQ+w5V/uKprpezC7fAsAMsJtJ+2rLKA==",
       "requires": {
+        "decode-uri-component": "0.2.0",
         "object-assign": "4.1.1",
         "strict-uri-encode": "1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "postcss-loader": "2.0.6",
     "promise": "7.1.1",
     "qrcode.react": "^0.7.2",
+    "query-string": "^5.0.1",
     "react": "^15.6.1",
     "react-alert": "^2.4.0",
     "react-copy-to-clipboard": "^5.0.1",

--- a/src/components/crowdsale/index.js
+++ b/src/components/crowdsale/index.js
@@ -9,7 +9,7 @@ import {
   getJoinedTiers,
   initializeAccumulativeData
 } from './utils'
-import { getQueryVariable, getURLParam, getWhiteListWithCapCrowdsaleAssets, toFixed } from '../../utils/utils'
+import { getQueryVariable, getWhiteListWithCapCrowdsaleAssets, toFixed } from '../../utils/utils'
 import { StepNavigation } from '../Common/StepNavigation'
 import { CONTRACT_TYPES, NAVIGATION_STEPS } from '../../utils/constants'
 import { invalidCrowdsaleAddrAlert } from '../../utils/alerts'
@@ -29,8 +29,6 @@ export class Crowdsale extends React.Component {
 
   componentDidMount () {
     checkWeb3()
-
-    this.setState({ tokenIsAlreadyCreated: true })
 
     const networkID = ICOConfig.networkID ? ICOConfig.networkID : getQueryVariable('networkID')
     const contractType = CONTRACT_TYPES.whitelistwithcap//getQueryVariable("contractType");
@@ -61,7 +59,7 @@ export class Crowdsale extends React.Component {
   extractContractsData = () => {
     const { contractStore, web3Store } = this.props
     const { web3 } = web3Store
-    const crowdsaleAddr = ICOConfig.crowdsaleContractURL ? ICOConfig.crowdsaleContractURL : getURLParam('addr')
+    const crowdsaleAddr = ICOConfig.crowdsaleContractURL ? ICOConfig.crowdsaleContractURL : getQueryVariable('addr')
 
     if (!web3.utils.isAddress(crowdsaleAddr)) {
       this.setState({ loading: false })
@@ -78,7 +76,7 @@ export class Crowdsale extends React.Component {
         return
       }
 
-      findCurrentContractRecursively(0, this, null, (crowdsaleContract) => {
+      findCurrentContractRecursively(0, null, (crowdsaleContract) => {
         if (!crowdsaleContract) {
           return this.setState({ loading: false })
         }
@@ -92,8 +90,10 @@ export class Crowdsale extends React.Component {
     getCrowdsaleData(crowdsaleContract)
       .then(() => initializeAccumulativeData())
       .then(() => {
+        return getAccumulativeCrowdsaleData()
+      })
+      .then(() => {
         this.setState({ loading: false })
-        getAccumulativeCrowdsaleData.call(this, () => {})
       })
       .catch(err => {
         this.setState({ loading: false })
@@ -151,8 +151,7 @@ export class Crowdsale extends React.Component {
 
     const tokensClaimedRatio = goalInETH ? (ethRaised / goalInETH) * 100 : "0";
 
-    return this.state.loading ? <Loader show={this.state.loading}></Loader> :
-    (
+    return (
       <section className="steps steps_crowdsale-page">
         <StepNavigation activeStep={CROWDSALE_PAGE} />
         <div className="steps-content container">

--- a/src/components/invest/index.js
+++ b/src/components/invest/index.js
@@ -11,7 +11,7 @@ import {
   getJoinedTiers,
   initializeAccumulativeData
 } from '../crowdsale/utils'
-import { getQueryVariable, getURLParam, getWhiteListWithCapCrowdsaleAssets, toast } from '../../utils/utils'
+import { getQueryVariable, getWhiteListWithCapCrowdsaleAssets, toast } from '../../utils/utils'
 import {
   invalidCrowdsaleAddrAlert,
   investmentDisabledAlertInTime, noGasPriceAvailable,
@@ -37,7 +37,7 @@ export class Invest extends React.Component {
       pristineTokenInput: true,
       web3Available: false,
       investThrough: INVESTMENT_OPTIONS.QR,
-      crowdsaleAddress: ICOConfig.crowdsaleContractURL || getURLParam('addr')
+      crowdsaleAddress: ICOConfig.crowdsaleContractURL || getQueryVariable('addr')
     }
   }
 
@@ -76,7 +76,7 @@ export class Invest extends React.Component {
     const { contractStore, crowdsalePageStore, web3Store } = this.props
     const { web3 } = web3Store
 
-    const crowdsaleAddr = ICOConfig.crowdsaleContractURL ? ICOConfig.crowdsaleContractURL : getURLParam('addr')
+    const crowdsaleAddr = ICOConfig.crowdsaleContractURL ? ICOConfig.crowdsaleContractURL : getQueryVariable('addr')
 
     if (!web3.utils.isAddress(crowdsaleAddr)) {
       this.setState({ loading: false })
@@ -105,7 +105,7 @@ export class Invest extends React.Component {
           return
         }
 
-        findCurrentContractRecursively(0, this, null, crowdsaleContract => {
+        findCurrentContractRecursively(0, null, crowdsaleContract => {
           if (!crowdsaleContract) {
             this.setState({ loading: false })
             return
@@ -113,7 +113,7 @@ export class Invest extends React.Component {
 
           initializeAccumulativeData()
             .then(() => getCrowdsaleData(crowdsaleContract))
-            .then(() => getAccumulativeCrowdsaleData.call(this, () => Promise.resolve()))
+            .then(() => getAccumulativeCrowdsaleData())
             .then(() => this.setState({ loading: false }))
             .catch(err => {
               this.setState({ loading: false })
@@ -170,7 +170,7 @@ export class Invest extends React.Component {
       return investmentDisabledAlertInTime(crowdsalePageStore.startDate)
     }
 
-    findCurrentContractRecursively(0, this, null, (crowdsaleContract, tierNum) => {
+    findCurrentContractRecursively(0, null, (crowdsaleContract, tierNum) => {
       if (!crowdsaleContract) {
         this.setState({ loading: false })
         return

--- a/src/components/manage/index.js
+++ b/src/components/manage/index.js
@@ -208,17 +208,18 @@ export class Manage extends Component {
               .then(reservedTokensDestinationsLen => {
 
                 let batchesLen
-                let batchesInt = Number(reservedTokensDestinationsLen / addressesPerBatch)
-                if (reservedTokensDestinationsLen % addressesPerBatch > 0)
+                let batchesInt = parseInt(reservedTokensDestinationsLen / addressesPerBatch, 10)
+                if (reservedTokensDestinationsLen % addressesPerBatch > 0) {
                   batchesLen = batchesInt + 1
-                else
+                } else {
                   batchesLen = batchesInt
+                }
 
                 const distributeMethod = crowdsaleContract.methods.distributeReservedTokens(addressesPerBatch)
                 let opts = {
                   gasPrice: this.props.generalStore.gasPrice
                 }
-                let batches = new Array(batchesLen);
+                let batches = Array.from(Array(batchesLen).keys());
                 this.distributeReservedTokensRecursive(batches, distributeMethod, opts)
                 .then(() => {
                   successfulDistributeAlert()
@@ -439,7 +440,7 @@ export class Manage extends Component {
           <p className="title">Distribute reserved tokens</p>
           <p className="description">Reserved tokens distribution is the last step of the crowdsale before finalization.
             You can make it only after the end of the last tier. If you reserved more then 100 addresses for your crowdsale, the distribution will be executed in batches with 100 reserved addresses per batch. Amount of batches is equal to amount of transactions</p>
-          <Link to='#' onClick={() => this.distributeReservedTokens(1)}>
+          <Link to='#' onClick={() => this.distributeReservedTokens(100)}>
             <span className={`button button_${!canDistribute ? 'disabled' : 'fill'}`}>Distribute tokens</span>
           </Link>
         </div>

--- a/src/components/manage/index.js
+++ b/src/components/manage/index.js
@@ -203,17 +203,11 @@ export class Manage extends Component {
           crowdsaleContract.methods.token().call()
           .then(token => {
             attachToContract(contractStore.token.abi, token)
-            .then(tokenContract => { // eslint-disable-line no-loop-func
+            .then(tokenContract => {
               tokenContract.methods.reservedTokensDestinationsLen().call()
               .then(reservedTokensDestinationsLen => {
 
-                let batchesLen
-                let batchesInt = parseInt(reservedTokensDestinationsLen / addressesPerBatch, 10)
-                if (reservedTokensDestinationsLen % addressesPerBatch > 0) {
-                  batchesLen = batchesInt + 1
-                } else {
-                  batchesLen = batchesInt
-                }
+                const batchesLen = Math.ceil(reservedTokensDestinationsLen / addressesPerBatch)
 
                 const distributeMethod = crowdsaleContract.methods.distributeReservedTokens(addressesPerBatch)
                 let opts = {

--- a/src/components/manage/index.js
+++ b/src/components/manage/index.js
@@ -6,10 +6,9 @@ import { CONTRACT_TYPES, TEXT_FIELDS, TOAST, VALIDATION_MESSAGES } from '../../u
 import { InputField } from '../Common/InputField'
 import '../../assets/stylesheets/application.css'
 import { WhitelistInputBlock } from '../Common/WhitelistInputBlock'
-import { successfulFinalizeAlert, successfulUpdateCrowdsaleAlert, warningOnFinalizeCrowdsale } from '../../utils/alerts'
-import { getNetworkVersion, sendTXToContract } from '../../utils/blockchainHelpers'
+import { successfulFinalizeAlert, successfulDistributeAlert, successfulUpdateCrowdsaleAlert, warningOnFinalizeCrowdsale } from '../../utils/alerts'
+import { getNetworkVersion, sendTXToContract, attachToContract, calculateGasLimit } from '../../utils/blockchainHelpers'
 import { getWhiteListWithCapCrowdsaleAssets, toast } from '../../utils/utils'
-import { getCurrentRate } from '../crowdsale/utils'
 import { contractsInfo, getTiers, processTier, updateTierAttribute } from './utils'
 import { Loader } from '../Common/Loader'
 
@@ -32,7 +31,9 @@ export class Manage extends Component {
     this.state = {
       formPristine: true,
       loading: true,
-      canFinalize: false
+      canFinalize: false,
+      canDistribute: false,
+      shouldDistribute: false
     }
   }
 
@@ -95,6 +96,8 @@ export class Manage extends Component {
   updateCrowdsaleStatus = () => {
     return contractsInfo()
       .then(this.setCrowdsaleInfo)
+      .then(this.shouldDistribute)
+      .then(this.canDistribute)
       .then(this.canFinalize)
   }
 
@@ -105,34 +108,143 @@ export class Manage extends Component {
     })
   }
 
-  canFinalize = () => {
-    const { web3Store, gasPriceStore } = this.props
-    const { web3 } = web3Store
+  shouldDistribute = () => {
+    const { contractStore, match } = this.props
 
     return new Promise(resolve => {
-      if (!this.state.crowdsaleHasEnded) {
+      attachToContract(contractStore.crowdsale.abi, match.params.crowdsaleAddress)
+      .then(crowdsaleContract => { // eslint-disable-line no-loop-func
+        console.log('attach to crowdsale contract')
+
+        if (!crowdsaleContract) return Promise.reject('No contract available')
+
+        crowdsaleContract.methods.token().call()
+        .then(tokenAddress => attachToContract(contractStore.token.abi, tokenAddress))
+        .then(tokenContract => tokenContract.methods.reservedTokensDestinationsLen().call())
+        .then((reservedTokensDestinationsLen) => {
+          if (reservedTokensDestinationsLen > 0)
+            this.setState({ shouldDistribute: true })
+          else
+            this.setState({ shouldDistribute: false })
+          resolve(this.state.shouldDistribute)
+        })
+        .catch(() => {
+          this.setState({ shouldDistribute: false })
+          resolve(this.state.shouldDistribute)
+        })
+      })
+    })
+  }
+
+  canDistribute = () => {
+    const { contractStore, match } = this.props
+
+    return new Promise(resolve => {
+      attachToContract(contractStore.crowdsale.abi, match.params.crowdsaleAddress)
+        .then(crowdsaleContract => { // eslint-disable-line no-loop-func
+          console.log('attach to crowdsale contract')
+
+          if (!crowdsaleContract) return Promise.reject('No contract available')
+
+          crowdsaleContract.methods.canDistributeReservedTokens().call((err, canDistributeReservedTokens) => {
+            return canDistributeReservedTokens;
+          }).then((canDistributeReservedTokens) => {
+            console.log("#canDistributeReservedTokens:", canDistributeReservedTokens);
+            this.setState({ canDistribute: canDistributeReservedTokens })
+            resolve(this.state.canDistribute)
+          })
+          .catch(() => {
+            this.setState({ canDistribute: false })
+            resolve(this.state.canDistribute)
+          })
+        })
+    })
+  }
+
+
+  canFinalize = () => {
+    const { contractStore, match } = this.props
+
+    return new Promise(resolve => {
+      if ((!this.state.crowdsaleHasEnded) || (this.state.shouldDistribute && this.state.canDistribute)) {
         this.setState({ canFinalize: false })
         resolve(this.state.canFinalize)
 
       } else {
-        web3.eth.estimateGas({
-          from: web3Store.curAddress,
-          to: this.state.lastContract._address,
-          data: '0x4bb278f3', // finalize signature
-          gas: web3.utils.toHex(650000),
-          gasPrice: web3.utils.toHex(gasPriceStore.slow.price),
-          value: web3.utils.toHex(0)
-        })
-          .then(() => {
-            this.setState({ canFinalize: true })
-            resolve(this.state.canFinalize)
-          })
-          .catch(() => {
-            this.setState({ canFinalize: false })
-            resolve(this.state.canFinalize)
+        attachToContract(contractStore.crowdsale.abi, match.params.crowdsaleAddress)
+          .then(crowdsaleContract => { // eslint-disable-line no-loop-func
+            console.log('attach to crowdsale contract')
+
+            if (!crowdsaleContract) return Promise.reject('No contract available')
+            crowdsaleContract.methods.finalized().call((err, finalized) => {
+              return finalized;
+            }).then((finalized) => {
+              this.setState({ canFinalize: !finalized })
+              resolve(this.state.canFinalize)
+            })
+            .catch(() => {
+              this.setState({ canFinalize: false })
+              resolve(this.state.canFinalize)
+            })
           })
       }
     })
+  }
+
+  distributeReservedTokens = (addressesPerBatch) => {
+    this.updateCrowdsaleStatus()
+      .then(() => {
+        const { crowdsaleStore, contractStore } = this.props
+
+        if (!crowdsaleStore.selected.distributed && this.state.canDistribute) {
+          this.showLoader()
+
+          const crowdsaleContract = this.state.lastContract
+          crowdsaleContract.methods.token().call()
+          .then(token => {
+            attachToContract(contractStore.token.abi, token)
+            .then(tokenContract => { // eslint-disable-line no-loop-func
+              tokenContract.methods.reservedTokensDestinationsLen().call()
+              .then(reservedTokensDestinationsLen => {
+
+                let batchesLen
+                let batchesInt = Number(reservedTokensDestinationsLen / addressesPerBatch)
+                if (reservedTokensDestinationsLen % addressesPerBatch > 0)
+                  batchesLen = batchesInt + 1
+                else
+                  batchesLen = batchesInt
+
+                const distributeMethod = crowdsaleContract.methods.distributeReservedTokens(addressesPerBatch)
+                let opts = {
+                  gasPrice: this.props.generalStore.gasPrice
+                }
+                let batches = new Array(batchesLen);
+                this.distributeReservedTokensRecursive(batches, distributeMethod, opts)
+                .then(() => {
+                  successfulDistributeAlert()
+                  crowdsaleStore.setSelectedProperty('distributed', true)
+                  this.setState({ canDistribute: false, canFinalize: true })
+                })
+                .catch(() => toast.showToaster({ type: TOAST.TYPE.ERROR, message: TOAST.MESSAGE.DISTRIBUTE_FAIL }))
+                .then(this.hideLoader)
+              })
+            })
+          })
+        }
+      })
+      .catch(console.error)
+  }
+
+  distributeReservedTokensRecursive = (batches, distributeMethod, opts) => {
+    return batches.reduce((promise) => {
+      return promise
+        .then(() => distributeMethod.estimateGas(opts)
+          .then(estimatedGas => {
+            opts.gasLimit = calculateGasLimit(estimatedGas)
+            return sendTXToContract(distributeMethod.send(opts))
+          })
+        )
+    }, Promise.resolve())
   }
 
   finalizeCrowdsale = () => {
@@ -147,13 +259,15 @@ export class Manage extends Component {
                 this.showLoader()
 
                 const crowdsaleContract = this.state.lastContract
-                const finalizeMethod = crowdsaleContract.methods.finalize().send({
-                  gasLimit: 650000,
+                const finalizeMethod = crowdsaleContract.methods.finalize()
+                let opts = {
                   gasPrice: this.props.generalStore.gasPrice
-                })
+                }
 
-                getCurrentRate(crowdsaleContract)
-                  .then(() => sendTXToContract(finalizeMethod))
+                finalizeMethod.estimateGas(opts)
+                .then(estimatedGas => {
+                  opts.gasLimit = calculateGasLimit(estimatedGas)
+                  sendTXToContract(finalizeMethod.send(opts))
                   .then(() => {
                     successfulFinalizeAlert()
                     crowdsaleStore.setSelectedProperty('finalized', true)
@@ -161,6 +275,7 @@ export class Manage extends Component {
                   })
                   .catch(() => toast.showToaster({ type: TOAST.TYPE.ERROR, message: TOAST.MESSAGE.FINALIZE_FAIL }))
                   .then(this.hideLoader)
+                })
               }
             })
         }
@@ -313,9 +428,23 @@ export class Manage extends Component {
   }
 
   render () {
-    const { formPristine, canFinalize, crowdsaleHasEnded } = this.state
+    const { formPristine, canFinalize, shouldDistribute, canDistribute, crowdsaleHasEnded } = this.state
     const { generalStore, tierStore, tokenStore, crowdsaleStore } = this.props
     const { address: crowdsaleAddress, finalized, updatable } = crowdsaleStore.selected
+
+    const distributeTokensStep = (
+      <div className="steps-content container">
+        <div className="about-step">
+          <div className="swal2-icon swal2-info warning-logo">!</div>
+          <p className="title">Distribute reserved tokens</p>
+          <p className="description">Reserved tokens distribution is the last step of the crowdsale before finalization.
+            You can make it only after the end of the last tier. If you reserved more then 100 addresses for your crowdsale, the distribution will be executed in batches with 100 reserved addresses per batch. Amount of batches is equal to amount of transactions</p>
+          <Link to='#' onClick={() => this.distributeReservedTokens(1)}>
+            <span className={`button button_${!canDistribute ? 'disabled' : 'fill'}`}>Distribute tokens</span>
+          </Link>
+        </div>
+      </div>
+    )
 
     const aboutStep = (
       <div className="about-step">
@@ -424,6 +553,7 @@ export class Manage extends Component {
 
     return (
       <section className="manage">
+        {shouldDistribute ? distributeTokensStep : null}
         <div className="steps-content container">
           {aboutStep}
         </div>

--- a/src/components/manage/utils.js
+++ b/src/components/manage/utils.js
@@ -25,7 +25,7 @@ export const updateTierAttribute = (attribute, value, addresses) => {
     endTime: 'setEndsAt',
     supply: 'setMaximumSellableTokens',
     rate: 'updateRate',
-    whitelist: 'setEarlyParticipantsWhitelist'
+    whitelist: 'setEarlyParticipantWhitelistMultiple'
   }
   let abi
   let contractAddresses
@@ -51,8 +51,8 @@ export const updateTierAttribute = (attribute, value, addresses) => {
   }
 
   if (attribute === 'rate') {
-    abi = contractStore.pricingStrategy.abi
-    contractAddresses = [addresses.pricingStrategyAddress]
+    abi = contractStore.crowdsale.abi
+    contractAddresses = [addresses.crowdsaleAddress]
     const oneTokenInETH = floorToDecimals(TRUNC_TO_DECIMALS.DECIMALS18, 1 / Number(value))
     value = [web3Store.web3.utils.toWei(oneTokenInETH, 'ether')]
   }

--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -14,7 +14,7 @@ import {
   handlerForFile,
   scrollToBottom,
   setFinalizeAgentRecursive,
-  setLastCrowdsaleRecursive,
+  setTierRecursive,
   setMintAgentRecursive,
   setReleaseAgentRecursive,
   setReservedTokensListMultiple,
@@ -338,8 +338,7 @@ const { PUBLISH } = NAVIGATION_STEPS
     console.log('web3Store', web3, web3.utils.toWei)
 
     return [
-      web3.utils.toWei(oneTokenInETH, 'ether'),
-      pricingStrategy.updatable ? pricingStrategy.updatable === 'on' : false
+      web3.utils.toWei(oneTokenInETH, 'ether')
     ]
   }
 
@@ -513,7 +512,7 @@ const { PUBLISH } = NAVIGATION_STEPS
     const tokenAddr = token.addr
     const crowdsaleAddr = crowdsale.addr
 
-    setLastCrowdsaleRecursive(pricingStrategyABI, pricingStrategy.addr, crowdsaleAddr.slice(-1)[0])
+    setTierRecursive(pricingStrategyABI, pricingStrategy.addr, crowdsaleAddr)
       .then(() => setReservedTokensListMultiple(tokenABI, tokenAddr, tokenStore, reservedTokenStore))
       .then(() => updateJoinedCrowdsalesRecursive(crowdsaleABI, crowdsaleAddr))
       .then(() => setMintAgentRecursive(tokenABI, tokenAddr, crowdsaleAddr, 'setMintAgentCrowdsale'))

--- a/src/components/stepFour/utils.js
+++ b/src/components/stepFour/utils.js
@@ -11,8 +11,8 @@ import { DOWNLOAD_NAME } from '../../utils/constants'
 import { isObservableArray } from 'mobx'
 import { generalStore, deploymentStore } from '../../stores'
 
-function setLastCrowdsale (abi, addr, lastCrowdsale) {
-  console.log('###setLastCrowdsale for Pricing Strategy:###')
+function setTier (abi, addr, tier) {
+  console.log('###setTier for Pricing Strategy:###')
 
   return attachToContract(abi, addr)
     .then(pricingStrategyContract => {
@@ -24,7 +24,7 @@ function setLastCrowdsale (abi, addr, lastCrowdsale) {
       }
 
       const opts = { gasPrice: generalStore.gasPrice }
-      const method = pricingStrategyContract.methods.setLastCrowdsale(lastCrowdsale)
+      const method = pricingStrategyContract.methods.setTier(tier)
 
       return method.estimateGas(opts)
         .then(estimatedGas => {
@@ -135,7 +135,7 @@ function addWhiteList (round, tierStore, token, abi, addr) {
       console.log('maxCaps:', maxCaps)
 
       const opts = { gasPrice: generalStore.gasPrice }
-      const method = crowdsaleContract.methods.setEarlyParticipantsWhitelist(addrs, statuses, minCaps, maxCaps)
+      const method = crowdsaleContract.methods.setEarlyParticipantWhitelistMultiple(addrs, statuses, minCaps, maxCaps)
 
       return method.estimateGas(opts)
         .then(estimatedGas => {
@@ -305,11 +305,11 @@ export function transferOwnership (abi, addr, finalizeAgentAddr) {
     })
 }
 
-export function setLastCrowdsaleRecursive (abi, pricingStrategyAddrs, lastCrowdsale) {
-  return pricingStrategyAddrs.reduce((promise, pricingStrategyAddr) => {
+export function setTierRecursive (abi, pricingStrategyAddrs, tiers) {
+  return pricingStrategyAddrs.reduce((promise, pricingStrategyAddr, index) => {
     return promise
-      .then(() => setLastCrowdsale(abi, pricingStrategyAddr, lastCrowdsale))
-      .then(() => deploymentStore.setAsSuccessful('lastCrowdsale'))
+      .then(() => setTier(abi, pricingStrategyAddr, tiers[index]))
+      .then(() => deploymentStore.setAsSuccessful('tier'))
   }, Promise.resolve())
 }
 

--- a/src/stores/DeploymentStore.js
+++ b/src/stores/DeploymentStore.js
@@ -12,7 +12,7 @@ class DeploymentStore {
       { name: 'crowdsale', dependsOnTiers: true, required: true },
       { name: 'registerCrowdsaleAddress', dependsOnTiers: false, required: true },
       { name: 'finalizeAgent', dependsOnTiers: true, required: true },
-      { name: 'lastCrowdsale', dependsOnTiers: true, required: true },
+      { name: 'tier', dependsOnTiers: true, required: true },
       { name: 'setReservedTokens', dependsOnTiers: false, required: hasReservedToken },
       { name: 'updateJoinedCrowdsales', dependsOnTiers: true, required: true },
       { name: 'setMintAgentCrowdsale', dependsOnTiers: true, required: true },

--- a/src/stores/GasPriceStore.js
+++ b/src/stores/GasPriceStore.js
@@ -1,6 +1,7 @@
 import { action, observable } from 'mobx'
 import { GAS_PRICE } from '../utils/constants'
 import { gweiToWei, weiToGwei } from '../utils/utils'
+import { gasPriceValues } from '../utils/api'
 
 class GasPriceStore {
   @observable slow
@@ -8,8 +9,8 @@ class GasPriceStore {
   @observable fast
   @observable instant
   @observable custom
-  @observable blockNumber
-  @observable blockTime
+  @observable block_number
+  @observable block_time
   @observable health
 
   constructor () {
@@ -62,9 +63,8 @@ class GasPriceStore {
     }
   }
 
-  @action updateValues = () => {
-    return fetch(GAS_PRICE.API.URL)
-      .then(response => response.json())
+  @action updateValues = (param) => {
+    return gasPriceValues(param)
       .then(oracle => {
         for (let key in oracle) {
           if (oracle.hasOwnProperty(key)) {
@@ -72,15 +72,6 @@ class GasPriceStore {
           }
         }
         return Promise.resolve()
-      })
-      .catch(error => {
-        this.setProperty('slow', weiToGwei(GAS_PRICE.SLOW.PRICE))
-        this.setProperty('fast', weiToGwei(GAS_PRICE.FAST.PRICE))
-        this.setProperty('standard', weiToGwei(GAS_PRICE.NORMAL.PRICE))
-        this.setProperty('instant', weiToGwei(GAS_PRICE.INSTANT.PRICE))
-        this.setProperty('custom', weiToGwei(GAS_PRICE.CUSTOM.PRICE))
-
-        return Promise.reject(error)
       })
   }
 }

--- a/src/stores/GasPriceStore.spec.js
+++ b/src/stores/GasPriceStore.spec.js
@@ -1,0 +1,99 @@
+import { GasPriceStore } from './GasPriceStore'
+import { GAS_PRICE } from '../utils/constants'
+import { gweiToWei } from '../utils/utils'
+
+jest.mock('../utils/api')
+
+describe('GasPriceStore', () => {
+  let gas
+
+  beforeEach(() => {
+    gas = new GasPriceStore
+  })
+
+  it('should instantiates store properly', () => {
+    expect(gas.slow).toBeDefined()
+    expect(gas.slow.id).toEqual(GAS_PRICE.SLOW.ID)
+    expect(gas.slow.price).toEqual(GAS_PRICE.SLOW.PRICE)
+    expect(gas.slow.description).toBeDefined()
+
+    expect(gas.standard).toBeDefined()
+    expect(gas.standard.id).toEqual(GAS_PRICE.NORMAL.ID)
+    expect(gas.standard.price).toEqual(GAS_PRICE.NORMAL.PRICE)
+    expect(gas.standard.description).toBeDefined()
+
+    expect(gas.fast).toBeDefined()
+    expect(gas.fast.id).toEqual(GAS_PRICE.FAST.ID)
+    expect(gas.fast.price).toEqual(GAS_PRICE.FAST.PRICE)
+    expect(gas.fast.description).toBeDefined()
+
+    expect(gas.instant).toBeDefined()
+    expect(gas.instant.id).toEqual(GAS_PRICE.INSTANT.ID)
+    expect(gas.instant.price).toEqual(GAS_PRICE.INSTANT.PRICE)
+    expect(gas.instant.description).toBeDefined()
+
+    expect(gas.custom).toBeDefined()
+    expect(gas.custom.id).toEqual(GAS_PRICE.CUSTOM.ID)
+    expect(gas.custom.price).toEqual(GAS_PRICE.CUSTOM.PRICE)
+    expect(gas.custom.description).toBeDefined()
+
+    expect(gas.block_number).toBeUndefined()
+    expect(gas.block_time).toBeUndefined()
+    expect(gas.health).toBeUndefined()
+  })
+
+  it('should updates values with mocked data', () => {
+    const gasPrice = require('../utils/__mocks__/gasPrice.json')
+
+    return gas.updateValues()
+      .then(() => {
+        expect(gas.slow.price).toEqual(gweiToWei(gasPrice.slow))
+        expect(gas.standard.price).toEqual(gweiToWei(gasPrice.standard))
+        expect(gas.fast.price).toEqual(gweiToWei(gasPrice.fast))
+        expect(gas.instant.price).toEqual(gweiToWei(gasPrice.instant))
+        expect(gas.custom.price).toEqual(GAS_PRICE.CUSTOM.PRICE)
+
+        expect(gas.block_number).toEqual(gasPrice.block_number)
+        expect(gas.block_time).toEqual(gasPrice.block_time)
+        expect(gas.health).toEqual(gasPrice.health)
+      })
+  })
+
+  it('should remain unchanged if a second call fails', () => {
+    const gasPrice = require('../utils/__mocks__/gasPrice.json')
+
+    return gas.updateValues()
+      .then(() => gas.updateValues('nonExisting'))
+      .catch((err) => {
+        expect(err).toEqual('no data')
+        expect(gas.slow.price).toEqual(gweiToWei(gasPrice.slow))
+        expect(gas.standard.price).toEqual(gweiToWei(gasPrice.standard))
+        expect(gas.fast.price).toEqual(gweiToWei(gasPrice.fast))
+        expect(gas.instant.price).toEqual(gweiToWei(gasPrice.instant))
+        expect(gas.custom.price).toEqual(GAS_PRICE.CUSTOM.PRICE)
+
+        expect(gas.block_number).toEqual(gasPrice.block_number)
+        expect(gas.block_time).toEqual(gasPrice.block_time)
+        expect(gas.health).toEqual(gasPrice.health)
+      })
+  })
+
+  it('should apply custom value', () => {
+    const CUSTOM_PRICE = 74.21
+
+    gas.setProperty('custom', CUSTOM_PRICE)
+
+    expect(gas.custom.price).toEqual(gweiToWei(CUSTOM_PRICE))
+  })
+
+  it('should preserve custom value after update', () => {
+    const CUSTOM_PRICE = 74.21
+
+    gas.setProperty('custom', CUSTOM_PRICE)
+
+    return gas.updateValues()
+      .then(() => {
+        expect(gas.custom.price).toEqual(gweiToWei(CUSTOM_PRICE))
+      })
+  })
+})

--- a/src/utils/__mocks__/api.js
+++ b/src/utils/__mocks__/api.js
@@ -1,0 +1,10 @@
+export const gasPriceValues = (endpoint = 'gasPrice') => {
+  return new Promise((resolve, reject) => {
+    try {
+      const data = require(`./${endpoint}`)
+      resolve(data)
+    } catch (e) {
+      reject('no data')
+    }
+  })
+}

--- a/src/utils/__mocks__/gasPrice.json
+++ b/src/utils/__mocks__/gasPrice.json
@@ -1,0 +1,9 @@
+{
+  "fast": 16.2,
+  "slow": 4.0,
+  "standard": 4.0,
+  "instant": 40.0,
+  "health": true,
+  "block_time": 14.528,
+  "block_number": 4949682
+}

--- a/src/utils/alerts.js
+++ b/src/utils/alerts.js
@@ -137,6 +137,14 @@ export function successfulFinalizeAlert() {
   })
 }
 
+export function successfulDistributeAlert() {
+  sweetAlert2({
+    title: "Success",
+    html: "Congrats! You've successfully distributed reserved tokens!",
+    type: "success"
+  })
+}
+
 export function noGasPriceAvailable() {
   sweetAlert2({
     title: "No Gas Price Available",

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,6 @@
+import { GAS_PRICE } from './constants'
+
+export const gasPriceValues = (endpoint = '') => {
+  return fetch(`${GAS_PRICE.API.URL}/${endpoint}`)
+    .then(response => response.json())
+}

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -397,7 +397,8 @@ export const TOAST = {
     TRANSACTION_FAILED: 'Transaction has failed, please retry',
     CONTRACT_DOWNLOAD_FAILED: 'Contract Download failed',
     CONTRACT_DOWNLOAD_SUCCESS: 'A file with contracts and metadata downloaded on your computer',
-    FINALIZE_FAIL: 'Was not able to finalize Crowdsale. Please be sure that Crowdsale has ended already'
+    FINALIZE_FAIL: 'Was not able to finalize Crowdsale. Please be sure that Crowdsale has ended already',
+    DISTRIBUTE_FAIL: 'Was not able to distribute reserved tokens'
   },
   DEFAULT_OPTIONS: {
     position: 'top right',
@@ -413,7 +414,7 @@ export const TX_STEP_DESCRIPTION = {
   crowdsale: "Deploy Crowdsale Contract",
   registerCrowdsaleAddress: "Associate Crowdsale address to current account",
   finalizeAgent: "Deploy Finalize Agent Contract",
-  lastCrowdsale: "Register last Tier address",
+  tier: "Register tier address for Pricing strategy",
   setReservedTokens: "Register addresses for Reserved Tokens",
   updateJoinedCrowdsales: "Register Crowdsales addresses",
   setMintAgentCrowdsale: "Allow Crowdsale Contract to Mint Tokens",

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,43 +1,10 @@
 import { VALIDATION_TYPES, TRUNC_TO_DECIMALS, TOAST } from './constants'
 import { contractStore, tokenStore, tierStore, web3Store } from '../stores'
+import queryString from 'query-string'
 const { VALID, INVALID } = VALIDATION_TYPES
 
 export function getQueryVariable(variable) {
-  var query = window.location.search.substring(1);
-  var vars = query.split('&');
-  for (var i = 0; i < vars.length; i++) {
-    var pair = vars[i].split('=');
-    if (decodeURIComponent(pair[0]) === variable) {
-      return decodeURIComponent(pair[1]);
-    }
-  }
-}
-
-export function getURLParam(key,target){
-  var values = [];
-  if(!target) {
-    target = window.location.href;
-  }
-
-  key = key.replace(/[[]/, "\\[").replace(/[\]]/, "\\]");
-
-  var pattern = key + '=([^&#]+)';
-  var o_reg = new RegExp(pattern,'ig');
-  while (true) {
-    var matches = o_reg.exec(target);
-    if(matches && matches[1]) {
-      values.push(matches[1]);
-    }
-    else {
-      break;
-    }
-  }
-
-  if (!values.length) {
-    return null;
-  } else {
-    return values.length === 1 ? values[0] : values;
-  }
+  return queryString.parse(window.location.search)[variable]
 }
 
 export function setFlatFileContentToState(file) {


### PR DESCRIPTION
As a result of security audit, contracts were updated with these PRs: https://github.com/poanetwork/ico/pull/14, https://github.com/poanetwork/ico/pull/15, https://github.com/poanetwork/ico/pull/16, https://github.com/poanetwork/ico/pull/17, https://github.com/poanetwork/ico/pull/18, https://github.com/poanetwork/ico/pull/19, https://github.com/poanetwork/ico/pull/20, https://github.com/poanetwork/ico/pull/21, https://github.com/poanetwork/ico/pull/22

Changes should be implemented in ICO Wizard due to audit:
- Finalization is in two steps: distribute reserved tokens (with batches) -> finalization

![screen shot 2018-01-30 at 22 41 19](https://user-images.githubusercontent.com/4341812/35587402-bec1cc32-060e-11e8-9dc9-0957559b0133.png)
- `setTier` instead of `setLastCrowdsale` for PricingStrategy contract
- `setEarlyParticipantsWhitelist` renamed to `setEarlyParticipantWhitelistMultiple`
- `updateRate` is from crowdsale contract now (not from Pricing strategy). All properties of crowdsale are managed from crowdsale contract
- Pricing strategy has only one parameter in constructor

Also, there are some new restrictions for the crowdsale owner,
- can set reserved tokens list only once
- can join tiers only once
- can't change rate of the tier, when it is active or finished
- can't change supply of the tier, when it is active or finished
- can't change start time of the tier, when it is active or finished
- can't change end time of the tier, when it is finished

@fernandomg @fvictorio please let me know if any your tests will fail. After merging of this PR we could consider opening wizard for mainnet.

