### PR TITLE
(Chore) Upgrade ganache-cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5452,11 +5452,12 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "ganache-cli": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.0.3.tgz",
-      "integrity": "sha512-C7a8su4Zwtootvcy9HtroshTsyUtLC51+aOGUREpy/G4CXbAuLa3nNQri2NyFdqGyOrm/D+jxYP/PWnnrGLyXg==",
+      "version": "6.1.0-beta.0",
+      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.1.0-beta.0.tgz",
+      "integrity": "sha512-uXObKQoKmLE6aRlVMBJpoQTW4byfF1vXX1YgwPlinGWnYAThMB4j04bBMj+t2kKQ3T/xVpHboGS0j+0Fopr0eg==",
       "dev": true,
       "requires": {
+        "source-map-support": "0.5.3",
         "webpack": "3.10.0"
       },
       "dependencies": {
@@ -5567,11 +5568,14 @@
             "read-pkg": "2.0.0"
           }
         },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+        "source-map-support": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
+          "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.6.1"
+          }
         },
         "string-width": {
           "version": "2.1.1",
@@ -5643,6 +5647,14 @@
             "watchpack": "1.4.0",
             "webpack-sources": "1.1.0",
             "yargs": "8.0.2"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            }
           }
         },
         "which-module": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-15": "^1.0.5",
     "ethereumjs-testrpc": "^4.1.3",
-    "ganache-cli": "^6.0.3",
+    "ganache-cli": "^6.1.0-beta.0",
     "gulp": "^3.9.1",
     "gulp-add-src": "^0.2.0",
     "gulp-autoprefixer": "^3.1.1",


### PR DESCRIPTION
`ganache-cli` is giving us some issues in the invest and manage pages (not really sure about the problem, but it seemed to be related with the gas estimation).

Upgrading it to `6.1.0-beta.0` seems to fix it. Since it's a dev dependency I think we'll be OK with using a beta version.